### PR TITLE
Add bearer token auth support for Salesforce connector

### DIFF
--- a/Package.md
+++ b/Package.md
@@ -111,8 +111,7 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-You can define the Salesforce configuration and create Salesforce base client as mentioned below.
-
+Users are recommended to use Direct-Token config when initializing the Salesforce client for the continuous access.  
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -130,6 +129,21 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
+If the user already owns a valid access token he initialize the client using Bearer-Token configuration as following for quick API calls. 
+
+```ballerina
+sfdc:SalesforceConfiguration sfConfig = {
+   baseUrl: <"EP_URL">,
+   clientConfig: {
+     token: <"ACCESS_TOKEN">
+   }
+};
+
+sfdc:Client baseClient = new (sfConfig);
+```
+
+This access token will be expired in 7200 seconds in general scenarios and the expiration time of the access token can be diferent from organization to organization. In such cases user have to get the new access token and update the configuration. 
+```
 
 If you want to add your own key store to define the `secureSocketConfig`, change the Salesforce configuration as mentioned below.
 

--- a/Package.md
+++ b/Package.md
@@ -111,7 +111,9 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-Users are recommended to use Direct-Token config when initializing the Salesforce client for the continuous access.  
+The Ballerina Salesforce connector has allowed users to create the client using the Direct Token Configuration and as well as Bearer Token Configuration. 
+
+Users are recommended to use Direct-Token config when initializing the Salesforce client for continuous access.   
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -129,7 +131,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-If the user already owns a valid access token he initialize the client using Bearer-Token configuration as following for quick API calls. 
+If the user already owns a valid access token he can initialize the client using Bearer-Token configuration as follows for quick API calls. 
 
 ```ballerina
 sfdc:SalesforceConfiguration sfConfig = {
@@ -142,8 +144,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-This access token will be expired in 7200 seconds in general scenarios and the expiration time of the access token can be diferent from organization to organization. In such cases user have to get the new access token and update the configuration. 
-```
+This access token will expire in 7200 seconds in general scenarios and the expiration time of the access token can be different from organization to organization. In such cases users have to get the new access token and update the configuration. 
 
 If you want to add your own key store to define the `secureSocketConfig`, change the Salesforce configuration as mentioned below.
 

--- a/Package.md
+++ b/Package.md
@@ -524,7 +524,7 @@ The above service is listening to the PushTopic `QuoteUpdate` defined in the Sal
 
 Please find the samples for above mentioned use cases through following links.
 
-## [Samples for Salesforce REST API use cases](samples/rest_api_usecases)  
+## [Samples for Salesforce REST API use cases](sfdc/samples/rest_api_usecases)  
 
 These samples demonstrate the employment of Ballerina Salesforce Connector in Salesforce REST API related operations. The samples can be further divided as following
 * Samples that can be used with any SObject's CRUD operations
@@ -533,11 +533,11 @@ These samples demonstrate the employment of Ballerina Salesforce Connector in Sa
 * Samples for retrieving Organization and SObject metadata
 
 
-## [Samples for Salesforce Bulk API use cases](samples/bulk_api_usecases)
+## [Samples for Salesforce Bulk API use cases](sfdc/samples/bulk_api_usecases)
 
 These samples demonstrate the employment of Ballerina Salesforce Connector in Salesforce BULK API related operations. Examples for bulk insert, bulk insert through files, bulk update, bulk upsert and bulk delete using json, csv or xml data sets are given here.
 
-## [Samples for Event Listener](samples/event_listener_usecases)
+## [Samples for Event Listener](sfdc/samples/event_listener_usecases)
 
 This sample demonstrates on capturing events using the Event Listener of Ballerina Salesforce Connector. As mentioned above to listen to a certin event users need to publish a pushtopic related to that event in his/her Salesforce instance. 
 

--- a/Package.md
+++ b/Package.md
@@ -111,9 +111,9 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-The Ballerina Salesforce connector has allowed users to create the client using the Direct Token Configuration and as well as Bearer Token Configuration. 
+The Ballerina Salesforce connector has allowed users to create the client using the [direct token configuration](https://ballerina.io/learn/by-example/secured-client-with-oauth2-direct-token-type.html) and as well as [bearer token configuration](https://ballerina.io/learn/by-example/secured-client-with-bearer-token-auth.html). 
 
-Users are recommended to use Direct-Token config when initializing the Salesforce client for continuous access.   
+Users are recommended to use direct-token config when initializing the Salesforce client for continuous access by providing the Salesfoce account's domain URL as the `baseURL` and the `client id`, `client secret`, `refresh token` obtained in the step two and `https://login.salesforce.com/services/oauth2/token` as `refreshUrl` in general scenarios. 
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -131,7 +131,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-If the user already owns a valid access token he can initialize the client using Bearer-Token configuration as follows for quick API calls. 
+If the user already owns a valid access token he can initialize the client using bearer-token configuration providing the access token as a bearer token for quick API calls. 
 
 ```ballerina
 sfdc:SalesforceConfiguration sfConfig = {

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-Ballerina Salesforce connector has allowed user to create the client using the Direct Token Configuration and as well as Bearer Token Configuration. 
+The Ballerina Salesforce connector has allowed users to create the client using the Direct Token Configuration and as well as Bearer Token Configuration. 
 
-Users are recommended to use Direct-Token config when initializing the Salesforce client for the continuous access.  
+Users are recommended to use Direct-Token config when initializing the Salesforce client for continuous access.   
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -139,7 +139,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-If the user already owns a valid access token he initialize the client using Bearer-Token configuration as following for quick API calls. 
+If the user already owns a valid access token he can initialize the client using Bearer-Token configuration as follows for quick API calls. 
 
 ```ballerina
 sfdc:SalesforceConfiguration sfConfig = {
@@ -152,7 +152,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-This access token will be expired in 7200 seconds in general scenarios and the expiration time of the access token can be diferent from organization to organization. In such cases user have to get the new access token and update the configuration. 
+This access token will expire in 7200 seconds in general scenarios and the expiration time of the access token can be different from organization to organization. In such cases users have to get the new access token and update the configuration. 
 
 
 If you want to add your own key store to define the `secureSocketConfig`, change the Salesforce configuration as mentioned below.

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ The above service is listening to the PushTopic `QuoteUpdate` defined in the Sal
 
 Please find the samples for above mentioned use cases through following links.
 
-## [Samples for Salesforce REST API use cases](samples/rest_api_usecases)  
+## [Samples for Salesforce REST API use cases](sfdc/samples/rest_api_usecases)  
 
 These samples demonstrate the employment of Ballerina Salesforce Connector in Salesforce REST API related operations. The samples can be further divided as following
 * Samples that can be used with any SObject's CRUD operations
@@ -543,11 +543,11 @@ These samples demonstrate the employment of Ballerina Salesforce Connector in Sa
 * Samples for retrieving Organization and SObject metadata
 
 
-## [Samples for Salesforce Bulk API use cases](samples/bulk_api_usecases)
+## [Samples for Salesforce Bulk API use cases](sfdc/samples/bulk_api_usecases)
 
 These samples demonstrate the employment of Ballerina Salesforce Connector in Salesforce BULK API related operations. Examples for bulk insert, bulk insert through files, bulk update, bulk upsert and bulk delete using json, csv or xml data sets are given here.
 
-## [Samples for Event Listener](samples/event_listener_usecases)
+## [Samples for Event Listener](sfdc/samples/event_listener_usecases)
 
 This sample demonstrates on capturing events using the Event Listener of Ballerina Salesforce Connector. As mentioned above to listen to a certin event users need to publish a pushtopic related to that event in his/her Salesforce instance. 
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-You can define the Salesforce configuration and create Salesforce base client as mentioned below.
+Ballerina Salesforce connector has allowed user to create the client using the Direct Token Configuration and as well as Bearer Token Configuration. 
 
+Users are recommended to use Direct-Token config when initializing the Salesforce client for the continuous access.  
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -137,6 +138,21 @@ sfdc:SalesforceConfiguration sfConfig = {
 
 sfdc:Client baseClient = new (sfConfig);
 ```
+
+If the user already owns a valid access token he initialize the client using Bearer-Token configuration as following for quick API calls. 
+
+```ballerina
+sfdc:SalesforceConfiguration sfConfig = {
+   baseUrl: <"EP_URL">,
+   clientConfig: {
+     token: <"ACCESS_TOKEN">
+   }
+};
+
+sfdc:Client baseClient = new (sfConfig);
+```
+
+This access token will be expired in 7200 seconds in general scenarios and the expiration time of the access token can be diferent from organization to organization. In such cases user have to get the new access token and update the configuration. 
 
 
 If you want to add your own key store to define the `secureSocketConfig`, change the Salesforce configuration as mentioned below.

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-The Ballerina Salesforce connector has allowed users to create the client using the Direct Token Configuration and as well as Bearer Token Configuration. 
+The Ballerina Salesforce connector has allowed users to create the client using the [direct token configuration](https://ballerina.io/learn/by-example/secured-client-with-oauth2-direct-token-type.html) and as well as [bearer token configuration](https://ballerina.io/learn/by-example/secured-client-with-bearer-token-auth.html). 
 
-Users are recommended to use Direct-Token config when initializing the Salesforce client for continuous access.   
+Users are recommended to use direct-token config when initializing the Salesforce client for continuous access by providing the Salesfoce account's domain URL as the `baseURL` and the `client id`, `client secret`, `refresh token` obtained in the step two and `https://login.salesforce.com/services/oauth2/token` as `refreshUrl` in general scenarios. 
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -139,7 +139,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-If the user already owns a valid access token he can initialize the client using Bearer-Token configuration as follows for quick API calls. 
+If the user already owns a valid access token he can initialize the client using bearer-token configuration providing the access token as a bearer token for quick API calls. 
 
 ```ballerina
 sfdc:SalesforceConfiguration sfConfig = {

--- a/sfdc/Module.md
+++ b/sfdc/Module.md
@@ -492,7 +492,7 @@ The above service is listening to the PushTopic `QuoteUpdate` defined in the Sal
 
 Please find the samples for above mentioned use cases through following links.
 
-## [Samples for Salesforce REST API use cases](../samples/rest_api_usecases)  
+## [Samples for Salesforce REST API use cases](samples/rest_api_usecases)  
 
 These samples demonstrate the employment of Ballerina Salesforce Connector in Salesforce REST API related operations. The samples can be further divided as following
 * Samples that can be used with any SObject's CRUD operations
@@ -501,11 +501,11 @@ These samples demonstrate the employment of Ballerina Salesforce Connector in Sa
 * Samples for retrieving Organization and SObject metadata
 
 
-## [Samples for Salesforce Bulk API use cases](../samples/bulk_api_usecases)
+## [Samples for Salesforce Bulk API use cases](samples/bulk_api_usecases)
 
 These samples demonstrate the employment of Ballerina Salesforce Connector in Salesforce BULK API related operations. Examples for bulk insert, bulk insert through files, bulk update, bulk upsert and bulk delete using json, csv or xml data sets are given here.
 
-## [Samples for Event Listener](../samples/event_listener_usecases)
+## [Samples for Event Listener](samples/event_listener_usecases)
 
 This sample demonstrates on capturing events using the Event Listener of Ballerina Salesforce Connector. As mentioned above to listen to a certin event users need to publish a pushtopic related to that event in his/her Salesforce instance. 
 

--- a/sfdc/Module.md
+++ b/sfdc/Module.md
@@ -81,9 +81,9 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-The Ballerina Salesforce connector has allowed users to create the client using the Direct Token Configuration and as well as Bearer Token Configuration. 
+The Ballerina Salesforce connector has allowed users to create the client using the [direct token configuration](https://ballerina.io/learn/by-example/secured-client-with-oauth2-direct-token-type.html) and as well as [bearer token configuration](https://ballerina.io/learn/by-example/secured-client-with-bearer-token-auth.html). 
 
-Users are recommended to use Direct-Token config when initializing the Salesforce client for continuous access.   
+Users are recommended to use direct-token config when initializing the Salesforce client for continuous access by providing the Salesfoce account's domain URL as the `baseURL` and the `client id`, `client secret`, `refresh token` obtained in the step two and `https://login.salesforce.com/services/oauth2/token` as `refreshUrl` in general scenarios. 
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -101,7 +101,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-If the user already owns a valid access token he can initialize the client using Bearer-Token configuration as follows for quick API calls. 
+If the user already owns a valid access token he can initialize the client using bearer-token configuration providing the access token as a bearer token for quick API calls. 
 
 ```ballerina
 sfdc:SalesforceConfiguration sfConfig = {

--- a/sfdc/Module.md
+++ b/sfdc/Module.md
@@ -81,7 +81,9 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-Users are recommended to use Direct-Token config when initializing the Salesforce client for the continuous access.  
+The Ballerina Salesforce connector has allowed users to create the client using the Direct Token Configuration and as well as Bearer Token Configuration. 
+
+Users are recommended to use Direct-Token config when initializing the Salesforce client for continuous access.   
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -99,7 +101,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-If the user already owns a valid access token he initialize the client using Bearer-Token configuration as following for quick API calls. 
+If the user already owns a valid access token he can initialize the client using Bearer-Token configuration as follows for quick API calls. 
 
 ```ballerina
 sfdc:SalesforceConfiguration sfConfig = {
@@ -112,7 +114,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-This access token will be expired in 7200 seconds in general scenarios and the expiration time of the access token can be diferent from organization to organization. In such cases user have to get the new access token and update the configuration. 
+This access token will expire in 7200 seconds in general scenarios and the expiration time of the access token can be different from organization to organization. In such cases users have to get the new access token and update the configuration. 
 
 If you want to add your own key store to define the `secureSocketConfig`, change the Salesforce configuration as mentioned below.
 

--- a/sfdc/Module.md
+++ b/sfdc/Module.md
@@ -81,8 +81,7 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-You can define the Salesforce configuration and create Salesforce base client as mentioned below.
-
+Users are recommended to use Direct-Token config when initializing the Salesforce client for the continuous access.  
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -100,9 +99,22 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
+If the user already owns a valid access token he initialize the client using Bearer-Token configuration as following for quick API calls. 
+
+```ballerina
+sfdc:SalesforceConfiguration sfConfig = {
+   baseUrl: <"EP_URL">,
+   clientConfig: {
+     token: <"ACCESS_TOKEN">
+   }
+};
+
+sfdc:Client baseClient = new (sfConfig);
+```
+
+This access token will be expired in 7200 seconds in general scenarios and the expiration time of the access token can be diferent from organization to organization. In such cases user have to get the new access token and update the configuration. 
 
 If you want to add your own key store to define the `secureSocketConfig`, change the Salesforce configuration as mentioned below.
-
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.

--- a/sfdc/Package.md
+++ b/sfdc/Package.md
@@ -495,7 +495,7 @@ The above service is listening to the PushTopic `QuoteUpdate` defined in the Sal
 
 Please find the samples for above mentioned use cases through following links.
 
-## [Samples for Salesforce REST API use cases](../samples/rest_api_usecases)  
+## [Samples for Salesforce REST API use cases](samples/rest_api_usecases)  
 
 These samples demonstrate the employment of Ballerina Salesforce Connector in Salesforce REST API related operations. The samples can be further divided as following
 * Samples that can be used with any SObject's CRUD operations
@@ -504,11 +504,11 @@ These samples demonstrate the employment of Ballerina Salesforce Connector in Sa
 * Samples for retrieving Organization and SObject metadata
 
 
-## [Samples for Salesforce Bulk API use cases](../samples/bulk_api_usecases)
+## [Samples for Salesforce Bulk API use cases](samples/bulk_api_usecases)
 
 These samples demonstrate the employment of Ballerina Salesforce Connector in Salesforce BULK API related operations. Examples for bulk insert, bulk insert through files, bulk update, bulk upsert and bulk delete using json, csv or xml data sets are given here.
 
-## [Samples for Event Listener](../samples/event_listener_usecases)
+## [Samples for Event Listener](samples/event_listener_usecases)
 
 This sample demonstrates on capturing events using the Event Listener of Ballerina Salesforce Connector. As mentioned above to listen to a certin event users need to publish a pushtopic related to that event in his/her Salesforce instance. 
 

--- a/sfdc/Package.md
+++ b/sfdc/Package.md
@@ -81,9 +81,9 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-The Ballerina Salesforce connector has allowed users to create the client using the Direct Token Configuration and as well as Bearer Token Configuration. 
+The Ballerina Salesforce connector has allowed users to create the client using the [direct token configuration](https://ballerina.io/learn/by-example/secured-client-with-oauth2-direct-token-type.html) and as well as [bearer token configuration](https://ballerina.io/learn/by-example/secured-client-with-bearer-token-auth.html). 
 
-Users are recommended to use Direct-Token config when initializing the Salesforce client for continuous access.   
+Users are recommended to use direct-token config when initializing the Salesforce client for continuous access by providing the Salesfoce account's domain URL as the `baseURL` and the `client id`, `client secret`, `refresh token` obtained in the step two and `https://login.salesforce.com/services/oauth2/token` as `refreshUrl` in general scenarios. 
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -101,7 +101,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-If the user already owns a valid access token he can initialize the client using Bearer-Token configuration as follows for quick API calls. 
+If the user already owns a valid access token he can initialize the client using bearer-token configuration providing the access token as a bearer token for quick API calls. 
 
 ```ballerina
 sfdc:SalesforceConfiguration sfConfig = {

--- a/sfdc/Package.md
+++ b/sfdc/Package.md
@@ -81,9 +81,9 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 ## Step 3: Create the Salesforce client
 
-You can define the Salesforce configuration and create Salesforce base client as mentioned below.
+The Ballerina Salesforce connector has allowed users to create the client using the Direct Token Configuration and as well as Bearer Token Configuration. 
 
-Users are recommended to use Direct-Token config when initializing the Salesforce client for the continuous access.  
+Users are recommended to use Direct-Token config when initializing the Salesforce client for continuous access.   
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -101,7 +101,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-If the user already owns a valid access token he initialize the client using Bearer-Token configuration as following for quick API calls. 
+If the user already owns a valid access token he can initialize the client using Bearer-Token configuration as follows for quick API calls. 
 
 ```ballerina
 sfdc:SalesforceConfiguration sfConfig = {
@@ -114,7 +114,7 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
-This access token will be expired in 7200 seconds in general scenarios and the expiration time of the access token can be diferent from organization to organization. In such cases user have to get the new access token and update the configuration. 
+This access token will expire in 7200 seconds in general scenarios and the expiration time of the access token can be different from organization to organization. In such cases users have to get the new access token and update the configuration. 
 
 If you want to add your own key store to define the `secureSocketConfig`, change the Salesforce configuration as mentioned below.
 

--- a/sfdc/Package.md
+++ b/sfdc/Package.md
@@ -83,6 +83,7 @@ Instantiate the connector by giving authentication details in the HTTP client co
 
 You can define the Salesforce configuration and create Salesforce base client as mentioned below.
 
+Users are recommended to use Direct-Token config when initializing the Salesforce client for the continuous access.  
 
 ```ballerina
 // Create Salesforce client configuration by reading from config file.
@@ -100,6 +101,20 @@ sfdc:SalesforceConfiguration sfConfig = {
 sfdc:Client baseClient = new (sfConfig);
 ```
 
+If the user already owns a valid access token he initialize the client using Bearer-Token configuration as following for quick API calls. 
+
+```ballerina
+sfdc:SalesforceConfiguration sfConfig = {
+   baseUrl: <"EP_URL">,
+   clientConfig: {
+     token: <"ACCESS_TOKEN">
+   }
+};
+
+sfdc:Client baseClient = new (sfConfig);
+```
+
+This access token will be expired in 7200 seconds in general scenarios and the expiration time of the access token can be diferent from organization to organization. In such cases user have to get the new access token and update the configuration. 
 
 If you want to add your own key store to define the `secureSocketConfig`, change the Salesforce configuration as mentioned below.
 

--- a/sfdc/auth_handler.bal
+++ b/sfdc/auth_handler.bal
@@ -22,14 +22,13 @@ import ballerina/http;
 # + authProvider - The `ClientOAuth2Provider` instance to handle auth requests. 
 public client class SalesforceAuthHandler {
 
-    oauth2:ClientOAuth2Provider|() authProvider;
+    oauth2:ClientOAuth2Provider? authProvider;
     string accessToken = "";
 
     public isolated function init(http:OAuth2DirectTokenConfig|http:BearerTokenConfig auth2Config) {
-        if (auth2Config is http:OAuth2DirectTokenConfig){
+        if (auth2Config is http:OAuth2DirectTokenConfig) {
             self.authProvider = new (auth2Config);
-        }
-        else {
+        } else {
             self.authProvider = ();
             self.accessToken = auth2Config.token;
         }
@@ -37,10 +36,9 @@ public client class SalesforceAuthHandler {
 
     public isolated function enrich(http:Request req) returns http:Request|http:ClientAuthError {
         string|oauth2:Error token;
-        if (self.authProvider is oauth2:ClientOAuth2Provider){
-            token = (<oauth2:ClientOAuth2Provider> self.authProvider).generateToken();
-        }
-        else {
+        if (self.authProvider is oauth2:ClientOAuth2Provider) {
+            token = (<oauth2:ClientOAuth2Provider>self.authProvider).generateToken();
+        } else {
             token = self.accessToken;
         }
 

--- a/sfdc/client_endpoint.bal
+++ b/sfdc/client_endpoint.bal
@@ -783,8 +783,8 @@ public client class Client {
 # + baseUrl - The Salesforce endpoint URL
 # + clientConfig - OAuth2 direct token configuration
 # + secureSocketConfig - HTTPS secure socket configuration
-public type SalesforceConfiguration record {
+public type SalesforceConfiguration record {|
     string baseUrl;
-    http:OAuth2DirectTokenConfig clientConfig;
+    http:OAuth2DirectTokenConfig|http:BearerTokenConfig clientConfig;
     http:ClientSecureSocket secureSocketConfig?;
-};
+|};

--- a/sfdc/tests/rest_api_test.bal
+++ b/sfdc/tests/rest_api_test.bal
@@ -20,14 +20,6 @@ import ballerina/os;
 
 // Create Salesforce client configuration by reading from environemnt.
 
-// Using bearer-token config for client configuration
-// SalesforceConfiguration sfConfig = {
-//     baseUrl: os:getEnv("EP_URL"),
-//     clientConfig: {
-//         token: os:getEnv("ACCESS_TOKEN")
-//     }
-// };
-
 // Using direct-token config for client configuration
 SalesforceConfiguration sfConfig = {
     baseUrl: os:getEnv("EP_URL"),
@@ -176,10 +168,12 @@ function testGetResourcesByApiVersion() {
 
     if (resources is map<string>) {
         test:assertTrue(resources.length() > 0, msg = "Found empty resource map");
+
         test:assertTrue((resources["sobjects"].toString().trim()).length() > 0, msg = "Found null for resource sobjects");
         test:assertTrue((resources["search"].toString().trim()).length() > 0, msg = "Found null for resource search");
         test:assertTrue((resources["query"].toString().trim()).length() > 0, msg = "Found null for resource query");
-        test:assertTrue((resources["licensing"].toString().trim()).length() > 0, msg = "Found null for resource licensing");
+        test:assertTrue((resources["licensing"].toString().trim()).length() > 0, 
+        msg = "Found null for resource licensing");
         test:assertTrue((resources["connect"].toString().trim()).length() > 0, msg = "Found null for resource connect");
         test:assertTrue((resources["tooling"].toString().trim()).length() > 0, msg = "Found null for resource tooling");
         test:assertTrue((resources["chatter"].toString().trim()).length() > 0, msg = "Found null for resource chatter");

--- a/sfdc/tests/rest_api_test.bal
+++ b/sfdc/tests/rest_api_test.bal
@@ -19,6 +19,16 @@ import ballerina/log;
 import ballerina/os;
 
 // Create Salesforce client configuration by reading from environemnt.
+
+// Using bearer-token config for client configuration
+// SalesforceConfiguration sfConfig = {
+//     baseUrl: os:getEnv("EP_URL"),
+//     clientConfig: {
+//         token: os:getEnv("ACCESS_TOKEN")
+//     }
+// };
+
+// Using direct-token config for client configuration
 SalesforceConfiguration sfConfig = {
     baseUrl: os:getEnv("EP_URL"),
     clientConfig: {


### PR DESCRIPTION
## Purpose
> Currently Ballerina Salesforce connector client initialization only support direct token configuration where user have to give client_id, client_secret, refresh_token and refresh url. It does not have the option to give only the access token when a user already owns an active access token. 

> Resolves https://github.com/wso2-enterprise/choreo/issues/2979

## Goals
> Allowing users to initialize the Salesforce connector by only using the access token.

## Release note
> If the user already owns a valid access token he can initialize the client using bearer-token configuration as follows for quick API calls. 
    
    sfdc:SalesforceConfiguration sfConfig = {
       baseUrl: <"EP_URL">,
       clientConfig: {
         token: <"ACCESS_TOKEN">
       }
    };
    
    sfdc:Client baseClient = new (sfConfig);

## Automation tests
 - Unit tests 
   > Successfully passing

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java JDK 11
> SL Alpha 2
> Salesforce API 48.0