### PR TITLE
Update connector version to 2.1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,41 @@ jobs:
             uses: actions/setup-java@v1
             with:
               java-version: 11
+          - name: 'Create settings.xml'
+            run: |
+                echo '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                            http://maven.apache.org/xsd/settings-1.0.0.xsd">
+                        <activeProfiles>
+                          <activeProfile>github</activeProfile>
+                        </activeProfiles>
+                        <profiles>
+                          <profile>
+                            <id>github</id>
+                            <repositories>
+                              <repository>
+                                <id>central</id>
+                                <url>https://repo1.maven.org/maven2</url>
+                                <releases><enabled>true</enabled></releases>
+                                <snapshots><enabled>true</enabled></snapshots>
+                              </repository>
+                              <repository>
+                                <id>github</id>
+                                <name>GitHub ballerina-platform Apache Maven Packages</name>
+                                <url>https://maven.pkg.github.com/ballerina-platform/ballerina-lang</url>
+                              </repository>
+                            </repositories>
+                          </profile>
+                        </profiles>
+                        <servers>
+                          <server>
+                            <id>github</id>
+                            <username>${{ secrets.USERNAME }}</username>
+                            <password>${{ secrets.PERSONAL_TOKEN }}</password>
+                          </server>
+                        </servers>
+                      </settings>' > ~/.m2/settings.xml
           - run: mvn clean package -pl emp-wrapper
           - name: Ballerina Build
             uses: ballerina-platform/ballerina-action/@swan-lake-connector-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,41 @@ jobs:
             uses: actions/setup-java@v1
             with:
               java-version: 11
+          - name: 'Create settings.xml'
+            run: |
+                echo '<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                            http://maven.apache.org/xsd/settings-1.0.0.xsd">
+                        <activeProfiles>
+                          <activeProfile>github</activeProfile>
+                        </activeProfiles>
+                        <profiles>
+                          <profile>
+                            <id>github</id>
+                            <repositories>
+                              <repository>
+                                <id>central</id>
+                                <url>https://repo1.maven.org/maven2</url>
+                                <releases><enabled>true</enabled></releases>
+                                <snapshots><enabled>true</enabled></snapshots>
+                              </repository>
+                              <repository>
+                                <id>github</id>
+                                <name>GitHub ballerina-platform Apache Maven Packages</name>
+                                <url>https://maven.pkg.github.com/ballerina-platform/ballerina-lang</url>
+                              </repository>
+                            </repositories>
+                          </profile>
+                        </profiles>
+                        <servers>
+                          <server>
+                            <id>github</id>
+                            <username>${{ secrets.USERNAME }}</username>
+                            <password>${{ secrets.PERSONAL_TOKEN }}</password>
+                          </server>
+                        </servers>
+                      </settings>' > ~/.m2/settings.xml
           - run: mvn clean install -pl emp-wrapper
           - name: Ballerina Build
             uses: ballerina-platform/ballerina-action/@swan-lake-connector-release

--- a/emp-wrapper/dependency-reduced-pom.xml
+++ b/emp-wrapper/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>sfdc-parent-connector</artifactId>
     <groupId>org.ballerinalang.sf</groupId>
-    <version>2.1.5</version>
+    <version>2.1.6</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>emp-wrapper</artifactId>
@@ -38,13 +38,13 @@
     <dependency>
       <groupId>org.ballerinalang</groupId>
       <artifactId>ballerina-runtime</artifactId>
-      <version>2.0.0-Preview8</version>
+      <version>2.0.0-alpha2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.ballerinalang</groupId>
       <artifactId>ballerina-lang</artifactId>
-      <version>2.0.0-Preview8</version>
+      <version>2.0.0-alpha2</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/emp-wrapper/pom.xml
+++ b/emp-wrapper/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.ballerinalang.sf</groupId>
         <artifactId>sfdc-parent-connector</artifactId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/emp-wrapper/src/main/java/org/ballerinalang/sf/Constants.java
+++ b/emp-wrapper/src/main/java/org/ballerinalang/sf/Constants.java
@@ -31,7 +31,7 @@ public class Constants {
 
     public static final String ORG = "ballerinax";
     public static final String MODULE = "sfdc";
-    public static final String VERSION = "2.1.5";
+    public static final String VERSION = "2.1.6";
     public static final String PACKAGE = ORG + ORG_NAME_SEPARATOR + MODULE + VERSION_SEPARATOR + VERSION;
     public static final Module PACKAGE_ID_SFDC = new Module(ORG, MODULE, VERSION);
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.ballerinalang.sf</groupId>
     <artifactId>sfdc-parent-connector</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.5</version>
+    <version>2.1.6</version>
     <modules>
         <module>emp-wrapper</module>
         <module>sfdc</module>
@@ -33,9 +33,9 @@
     <url>http://maven.apache.org</url>
     <repositories>
         <repository>
-            <id>wso2-nexus</id>
-            <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <id>github.releases</id>
+            <name>GitHub ballerina-platform Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/ballerina-platform/ballerina-lang</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -62,7 +62,7 @@
     <properties>
         <project-home>${project.basedir}</project-home>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ballerina.version>2.0.0-Preview8</ballerina.version>
+        <ballerina.version>2.0.0-alpha2</ballerina.version>
         <exec.maven.plugin.version>1.6.0</exec.maven.plugin.version>
         <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
         <maven.dependency.plugin.version>3.0.2</maven.dependency.plugin.version>

--- a/sfdc/Ballerina.toml
+++ b/sfdc/Ballerina.toml
@@ -1,17 +1,17 @@
 [package]
 org = "ballerinax"
 name = "sfdc"
-version = "2.1.5"
+version = "2.1.6"
 
 [build-options]
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../emp-wrapper/target/emp-wrapper-2.1.5.jar"
+path = "../emp-wrapper/target/emp-wrapper-2.1.6.jar"
 groupId = "org.ballerinalang.sf"
 artifactId = "emp-wrapper"
 module = "emp-wrapper" 
-version = "2.1.5"
+version = "2.1.6"
 
 
 

--- a/sfdc/Module.md
+++ b/sfdc/Module.md
@@ -8,7 +8,7 @@ The Salesforce connector allows users to perform CRUD operations for SObjects, q
 ## Compatibility
 |                     |    Version                  |
 |:-------------------:|:---------------------------:|
-| Ballerina Language  | swan-lake-preview8          |
+| Ballerina Language  | swan-lake-Alpha2            |
 | Salesforce API      | v48.0                       |
 | Salesforce Bulk API | v1                          |
 

--- a/sfdc/Package.md
+++ b/sfdc/Package.md
@@ -8,7 +8,7 @@ The Salesforce connector allows users to perform CRUD operations for SObjects, q
 ## Compatibility
 |                     |    Version                  |
 |:-------------------:|:---------------------------:|
-| Ballerina Language  | swan-lake-preview8          |
+| Ballerina Language  | swan-lake-Alpha2            |
 | Salesforce API      | v48.0                       |
 | Salesforce Bulk API | v1                          |
 

--- a/sfdc/pom.xml
+++ b/sfdc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>sfdc-parent-connector</artifactId>
         <groupId>org.ballerinalang.sf</groupId>
-        <version>2.1.5</version>
+        <version>2.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>sfdc</artifactId>


### PR DESCRIPTION
## Purpose
> update Ballerina Salesforce connector version to 2.1.6
> update emp-wrapper's ballerina bersion to SL Alpha2

## Goals
> release the connector with bulk operations to choreo 

## Release note
> Please add two new secrets to `ballerinax.sfdc` repo as
1. USERNAME - Common Credential's GitHub username
2. PERSONAL_TOKEN - Common Credential's GitHub PAT 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Java jdk 11
> Ballerina SL Alpha 2