### PR TITLE
[SNAPSHOT] Apply new changes to the Salesforce Listener module

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ json accountRecord = {
    BillingCity: "Colombo 3"
  };
 
-string|sfdc:Error recordId = baseClient->createRecord("Account", accountRecord);
+string|sfdc:Error recordId = baseClient->createRecord(ACCOUNT, accountRecord);
 ```
 
 #### Get Record
@@ -230,7 +230,7 @@ json account = {
        BillingCity: "Jaffna",
        Phone: "+94110000000"
    };
-sfdc:Error? result = baseClient->updateRecord("Account", testRecordId, account);
+sfdc:Error? result = baseClient->updateRecord(ACCOUNT, testRecordId, account);
 ```
 
 #### Delete Record
@@ -239,7 +239,7 @@ SObject Name and the SObject record id as parameters and the function will retur
 
 ```ballerina
 string testRecordId = "001xa000003DIlo";
-sfdc:Error? result = baseClient->deleteRecord("Account", testRecordId);
+sfdc:Error? result = baseClient->deleteRecord(ACCOUNT, testRecordId);
 ```
 
 ### Convenient CRUD Operations for Common SObjects
@@ -495,7 +495,7 @@ Now, a service has to be defined on the ‘eventListener’ like the following.
 
 ```ballerina
 @sfdc:ServiceConfig {
-    topic:"/data/ChangeEvents"
+    channelName:"/data/ChangeEvents"
 }
 service quoteUpdate on eventListener {
     resource function onUpdate (sfdc:EventData quoteUpdate) { 
@@ -544,9 +544,10 @@ data sets are given here.
 
 ## [Samples for Event Listener](sfdc/samples/event_listener_usecases)
 This sample demonstrates on capturing events using the Event Listener of Ballerina Salesforce Connector. As mentioned 
-above to listen to a certin event users need to publish a pushtopic related to that event in his/her Salesforce instance. 
+above to listen to a certin event users need to select Objects for Change Notifications in the user interface in his/her Salesforce instance. 
+  - [Select SObjects](https://developer.salesforce.com/docs/atlas.en-us.change_data_capture.meta/change_data_capture/cdc_select_objects.htm) 
   - [Trigger Account Updates](sfdc/samples/event_listener_usecases/listener_account_update.bal)
-
+ 
 
 # Building from the Source
 ## Setting up the prerequisites

--- a/emp-wrapper/src/main/java/org/ballerinalang/sf/Constants.java
+++ b/emp-wrapper/src/main/java/org/ballerinalang/sf/Constants.java
@@ -35,22 +35,37 @@ public class Constants {
     public static final String PACKAGE = ORG + ORG_NAME_SEPARATOR + MODULE + VERSION_SEPARATOR + VERSION;
     public static final Module PACKAGE_ID_SFDC = new Module(ORG, MODULE, VERSION);
 
-    // EventData constant fields
+    /* Event Record type names */
     public static final String EVENT_DATA_RECORD = "EventData";
     public static final String EVENT_METADATA_RECORD = "ChangeEventMetadata";
 
-    public static final String SERVICE_CONFIG = "ServiceConfig";
+    /* EventData payload fields */
+    public static final String COMMIT_TIME_STAMP = "commitTimestamp";
+    public static final String TRANSACTION_KEY = "transactionKey";
+    public static final String CHANGE_ORIGIN = "changeOrigin";
+    public static final String ENTITY_NAME = "entityName";
+    public static final String SEQUENCE_NUMBER = "sequenceNumber";
+    public static final String COMMIT_USER = "commitUser";
+    public static final String COMMIT_NUMBER = "commitNumber";
+    public static final String RECORD_IDS = "recordIds";
+    public static final String EVENT_PAYLOAD = "payload";
+    public static final String EVENT_HEADER = "ChangeEventHeader";
+    public static final String EVENT_CHANGE_TYPE = "changeType";
+
+    /* Events */
     public static final String ON_CREATE = "onCreate";
     public static final String ON_UPDATE = "onUpdate";
     public static final String ON_DELETE = "onDelete";
     public static final String ON_RESTORE = "onRestore";
+    public static final String UPDATE = "UPDATE";
+    public static final String CREATE = "CREATE";
+    public static final String DELETE = "DELETE";
+    public static final String UNDELETE = "UNDELETE";
 
-    public static final BString TOPIC_NAME = StringUtils.fromString("topic");
+    /* Annotation data*/
+    public static final String SERVICE_CONFIG = "ServiceConfig";
+    public static final BString CHANNEL_NAME = StringUtils.fromString("channelName");
     public static final BString REPLAY_FROM = StringUtils.fromString("replayFrom");
 
     public static final String SFDC_ERROR = "SFDC_Error";
-
-    public static final String EVENT_PAYLOAD = "payload";
-    public static final String EVENT_HEADER = "ChangeEventHeader";
-    public static final String EVENT_CHANGE_TYPE = "changeType";
 }

--- a/sfdc/Module.md
+++ b/sfdc/Module.md
@@ -462,7 +462,7 @@ Now, a service has to be defined on the ‘eventListener’ like the following.
 
 ```ballerina
 @sfdc:ServiceConfig {
-    topic:"/data/ChangeEvents"
+    channelName:"/data/ChangeEvents"
 }
 service quoteUpdate on eventListener {
     resource function onUpdate (sfdc:EventData quoteUpdate) { 
@@ -494,8 +494,8 @@ data sets are given here.
 
 ## [Samples for Event Listener](samples/event_listener_usecases)
 This sample demonstrates on capturing events using the Event Listener of Ballerina Salesforce Connector. As mentioned 
-above to listen to a certin event users need to publish a pushtopic related to that event in his/her Salesforce instance. 
-
+above to listen to a certin event users need to select Objects for Change Notifications in the user interface in his/her Salesforce instance. 
+- [Select SObjects](https://developer.salesforce.com/docs/atlas.en-us.change_data_capture.meta/change_data_capture/cdc_select_objects.htm)
 # Building from the Source
 ## Setting up the prerequisites
 *   Download and install Java SE Development Kit (JDK) version 11 (from one of the following locations).

--- a/sfdc/Package.md
+++ b/sfdc/Package.md
@@ -457,7 +457,7 @@ Now, a service has to be defined on the ‘eventListener’ like the following.
 
 ```ballerina
 @sfdc:ServiceConfig {
-    topic:"/data/ChangeEvents"
+    channelName:"/data/ChangeEvents"
 }
 service quoteUpdate on eventListener {
     resource function onUpdate (sfdc:EventData quoteUpdate) { 
@@ -488,7 +488,8 @@ data sets are given here.
 
 ## [Samples for Event Listener](samples/event_listener_usecases)
 This sample demonstrates on capturing events using the Event Listener of Ballerina Salesforce Connector. As mentioned 
-above to listen to a certin event users need to publish a pushtopic related to that event in his/her Salesforce instance. 
+above to listen to a certin event users need to select Objects for Change Notifications in the user interface in his/her Salesforce instance. 
+- [Select SObjects](https://developer.salesforce.com/docs/atlas.en-us.change_data_capture.meta/change_data_capture/cdc_select_objects.htm) 
 
 # References
 Trailhead Salesforce Documentation -

--- a/sfdc/listener.bal
+++ b/sfdc/listener.bal
@@ -92,12 +92,12 @@ const REPLAY_FROM_EARLIEST = -2;
 
 public type ReplayFrom REPLAY_FROM_TIP|REPLAY_FROM_EARLIEST;
 
-public type SFDCTopicConfigData record {|
-    string topic;
+public type SFDCChannelConfigData record {|
+    string channelName;
     ReplayFrom replayFrom = REPLAY_FROM_TIP;
 |};
 
-public annotation SFDCTopicConfigData ServiceConfig on service;
+public annotation SFDCChannelConfigData ServiceConfig on service;
 
 # A record type which contains data returned from a Change Data Event.
 #
@@ -119,6 +119,7 @@ public type EventData record {
 # + sequenceNumber - Identifies the sequence of the change within a transaction
 # + commitUser - The ID of the user that ran the change operation
 # + commitNumber - The system change number (SCN) of a committed transaction
+# + recordId - The record ID for the changed record
 public type ChangeEventMetadata record {
     int commitTimestamp?;
     string transactionKey?;
@@ -128,4 +129,5 @@ public type ChangeEventMetadata record {
     int sequenceNumber?;
     string commitUser?;
     int commitNumber?;
+    string recordId?;
 };

--- a/sfdc/samples/README.md
+++ b/sfdc/samples/README.md
@@ -10,11 +10,11 @@ These samples demonstrate the employment of Ballerina Salesforce Connector in Sa
 * Samples for SOSL and SOQL related operations
 * Samples for retrieving Organization and SObject metadata
 
-
 ## [Samples for Salesforce Bulk API use cases](bulk_api_usecases)
 
 These samples demonstrate the employment of Ballerina Salesforce Connector in Salesforce BULK API related operations. Examples for bulk insert, bulk insert through files, bulk update, bulk upsert and bulk delete using json, csv or xml data sets are given here.
 
 ## [Samples for Event Listener](event_listener_usecases)
 
-This sample demonstrates on capturing events using the Event Listener of Ballerina Salesforce Connector. As mentioned above to listen to a certin event users need to publish a pushtopic related to that event in his/her Salesforce instance. 
+This sample demonstrates on capturing events using the Event Listener of Ballerina Salesforce Connector. As mentioned above to listen to a certin event users need to select Objects for Change Notifications in the user interface in his/her Salesforce instance. 
+- [Select SObjects](https://developer.salesforce.com/docs/atlas.en-us.change_data_capture.meta/change_data_capture/cdc_select_objects.htm)

--- a/sfdc/samples/event_listener_usecases/listener_account_update.bal
+++ b/sfdc/samples/event_listener_usecases/listener_account_update.bal
@@ -25,7 +25,7 @@ sfdc:ListenerConfiguration listenerConfig = {
 listener sfdc:Listener eventListener = new (listenerConfig);
 
 //service to catch event when an account is updated
-@sfdc:ServiceConfig {topic: "/data/ChangeEvents"}
+@sfdc:ServiceConfig {channelName: "/data/ChangeEvents"}
 service on eventListener {
     remote function onUpdate(sfdc:EventData op) {
         json accountName = op.changedData.get("Name");

--- a/sfdc/tests/listener_test.bal
+++ b/sfdc/tests/listener_test.bal
@@ -29,14 +29,14 @@ ListenerConfiguration listenerConfig = {
 listener Listener eventListener = new (listenerConfig);
 boolean isUpdated = false;
 
-@ServiceConfig {topic: "/data/ChangeEvents"}
+@ServiceConfig {channelName: "/data/ChangeEvents"}
 service on eventListener {
-    remote function onUpdate(EventData op) {
-        json accountName = op.changedData.get("Name");
+    remote function onUpdate(EventData event) {
+        json accountName = event.changedData.get("Name");
         if (accountName.toString() == "WSO2 Inc") {
             isUpdated = true;
         } else {
-            io:println(op.toString());
+            io:println(event.toString());
         }
     }
 }


### PR DESCRIPTION
## Purpose
> Rename the listener  configuration for the custom annotation
> Provide constants for the hard coded field names in the listener code
> Include a new field to the listener record type

## Goals
> To provide a clear meaning in the configuration annotation when using the Change Data events 
> To get the value of the updated record ID as a field to the listener record type

## Automation tests
 - Unit tests 
   > Done
 - Integration tests
   > Done

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Ballerina beta.1
> JDK 11
> Ubuntu 20.04 LTS