### PR TITLE
Change ballerina action to @slalpha5 github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
                       </settings>' > ~/.m2/settings.xml
           - run: mvn clean package -pl emp-wrapper
           - name: Ballerina Build
-            uses: ballerina-platform/ballerina-action/@master
+            uses: ballerina-platform/ballerina-action/@slalpha5
             with:
               args:
                 build -c ./sfdc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
                       </settings>' > ~/.m2/settings.xml
           - run: mvn clean install -pl emp-wrapper
           - name: Ballerina Build
-            uses: ballerina-platform/ballerina-action/@master
+            uses: ballerina-platform/ballerina-action/@slalpha5
             with:
               args:
                 build -c --skip-tests ./sfdc
@@ -67,7 +67,7 @@ jobs:
                 SF_PASSWORD: ${{ secrets.SF_PASSWORD }}
                 SF_USERNAME: ${{ secrets.SF_USERNAME }}
           - name: Ballerina Push
-            uses: ballerina-platform/ballerina-action/@master
+            uses: ballerina-platform/ballerina-action/@slalpha5
             with:
               args:
                 push 


### PR DESCRIPTION
## Purpose
Change the ballerina action to `@slalpha5` in github workflow yaml files.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLAlpha5
