### PR TITLE
Fix version of emp-wrapper jar file and bump version to 2.2.1

### DIFF
--- a/emp-wrapper/src/main/java/org/ballerinalang/sf/Constants.java
+++ b/emp-wrapper/src/main/java/org/ballerinalang/sf/Constants.java
@@ -31,7 +31,7 @@ public class Constants {
 
     public static final String ORG = "ballerinax";
     public static final String MODULE = "sfdc";
-    public static final String VERSION = "2.1.9-SNAPSHOT";
+    public static final String VERSION = "2.2.1";
     public static final String PACKAGE = ORG + ORG_NAME_SEPARATOR + MODULE + VERSION_SEPARATOR + VERSION;
     public static final Module PACKAGE_ID_SFDC = new Module(ORG, MODULE, VERSION);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=org.ballerinalang.sf
-version=2.2.0
+version=2.2.1
 ballerinaLangVersion=2.0.0-beta.2.1

--- a/sfdc/Ballerina.toml
+++ b/sfdc/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "sfdc"
-version = "2.2.0"
+version = "2.2.1"
 export = ["sfdc", "sfdc.bulk", "sfdc.soap"]
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
@@ -12,8 +12,8 @@ repository = "https://github.com/ballerina-platform/module-ballerinax-sfdc"
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../emp-wrapper/build/libs/emp-wrapper-2.2.0-all.jar"
+path = "../emp-wrapper/build/libs/emp-wrapper-2.2.1-all.jar"
 groupId = "org.ballerinalang.sf"
 artifactId = "emp-wrapper"
 module = "emp-wrapper" 
-version = "2.2.0"
+version = "2.2.1"


### PR DESCRIPTION
## Purpose
Bump connector version to 2.2.1

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta2
