### PR TITLE
Rename config record as `ConnectionConfig` and add support for all `http:ClientConfiguration` fields

### DIFF
--- a/sfdc/Module.md
+++ b/sfdc/Module.md
@@ -23,9 +23,9 @@ import ballerinax/sfdc;
 ```
 
 #### Step 2: Create a new connector instance
-Create a `sfdc:SalesforceConfiguration` with the OAuth2 tokens obtained, and initialize the connector with it.
+Create a `sfdc:ConnectionConfig` with the OAuth2 tokens obtained, and initialize the connector with it.
 ```ballerina
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
    baseUrl: <"EP_URL">,
    clientConfig: {
      clientId: <"CLIENT_ID">,

--- a/sfdc/modules/bulk/Module.md
+++ b/sfdc/modules/bulk/Module.md
@@ -20,10 +20,10 @@ import ballerinax/sfdc.bulk;
 ```
 
 ### Step 2: Create a new connector instance
-Create a `sfdc:SalesforceConfiguration` with the OAuth2 tokens obtained, and initialize the connector with it.
+Create a `sfdc:ConnectionConfig` with the OAuth2 tokens obtained, and initialize the connector with it.
 ```ballerina
 
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
    baseUrl: <"EP_URL">,
    clientConfig: {
      clientId: <"CLIENT_ID">,

--- a/sfdc/modules/bulk/tests/utils.bal
+++ b/sfdc/modules/bulk/tests/utils.bal
@@ -38,7 +38,7 @@ configurable string & readonly refreshUrl = os:getEnv("REFRESH_URL");
 configurable string & readonly baseUrl = os:getEnv("EP_URL");
 
 // Using direct-token config for client configuration
-SalesforceConfiguration sfConfig = {
+ConnectionConfig sfConfig = {
     baseUrl: baseUrl,
     clientConfig: {
         clientId: clientId,

--- a/sfdc/modules/soap/Module.md
+++ b/sfdc/modules/soap/Module.md
@@ -21,10 +21,10 @@ import ballerinax/sfdc.soap;
 ```
 
 ### Step 2: Create a new connector instance
-Create a `sfdc:SalesforceConfiguration` with the OAuth2 tokens obtained, and initialize the connector with it.
+Create a `sfdc:ConnectionConfig` with the OAuth2 tokens obtained, and initialize the connector with it.
 
 ```ballerina
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
    baseUrl: <"EP_URL">,
    clientConfig: {
      clientId: <"CLIENT_ID">,

--- a/sfdc/modules/soap/client.bal
+++ b/sfdc/modules/soap/client.bal
@@ -39,7 +39,7 @@ public isolated client class Client {
     # 
     # + salesforceConfig - Salesforce Connector configuration
     # + return - An error on failure of initialization or else `()`
-    public isolated function init(sfdc:SalesforceConfiguration salesforceConfig) returns error? {
+    public isolated function init(sfdc:ConnectionConfig salesforceConfig) returns error? {
         self.clientConfig = salesforceConfig.clientConfig.cloneReadOnly();
         http:ClientSecureSocket? socketConfig = salesforceConfig?.secureSocketConfig;
 
@@ -56,7 +56,22 @@ public isolated client class Client {
             return error(sfdc:INVALID_CLIENT_CONFIG);
         }
 
-        http:Client|error httpClientResult = trap new (salesforceConfig.baseUrl, {secureSocket: socketConfig});
+        http:Client|error httpClientResult = trap new (salesforceConfig.baseUrl, {
+            secureSocket: socketConfig,
+            httpVersion: salesforceConfig.httpVersion,
+            http1Settings: salesforceConfig.http1Settings,
+            http2Settings: salesforceConfig.http2Settings,
+            timeout: salesforceConfig.timeout,
+            forwarded: salesforceConfig.forwarded,
+            followRedirects: salesforceConfig.followRedirects,
+            poolConfig: salesforceConfig.poolConfig,
+            cache: salesforceConfig.cache,
+            compression: salesforceConfig.compression,
+            circuitBreaker: salesforceConfig.circuitBreaker,
+            retryConfig: salesforceConfig.retryConfig,
+            cookieConfig: salesforceConfig.cookieConfig,
+            responseLimits: salesforceConfig.responseLimits
+        });
 
         if (httpClientResult is http:Client) {
             self.salesforceClient = httpClientResult;

--- a/sfdc/modules/soap/tests/test.bal
+++ b/sfdc/modules/soap/tests/test.bal
@@ -25,7 +25,7 @@ configurable string refreshToken = os:getEnv("REFRESH_TOKEN");
 configurable string refreshUrl = os:getEnv("REFRESH_URL");
 configurable string baseUrl = os:getEnv("EP_URL");
 
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: baseUrl,
     clientConfig: {
         clientId: clientId,

--- a/sfdc/rest_client.bal
+++ b/sfdc/rest_client.bal
@@ -34,14 +34,27 @@ public isolated client class Client {
     # 
     # + salesforceConfig - Salesforce Connector configuration
     # + return - `sfdc:Error` on failure of initialization or else `()`
-    public isolated function init(SalesforceConfiguration salesforceConfig) returns Error? {
+    public isolated function init(ConnectionConfig salesforceConfig) returns Error? {
         self.clientConfig = salesforceConfig.clientConfig.cloneReadOnly();
         http:ClientSecureSocket? socketConfig = salesforceConfig?.secureSocketConfig;
 
         http:Client|http:ClientError|error httpClientResult;
         httpClientResult = trap new (salesforceConfig.baseUrl, {
             auth: salesforceConfig.clientConfig,
-            secureSocket: socketConfig
+            secureSocket: socketConfig,
+            httpVersion: salesforceConfig.httpVersion,
+            http1Settings: salesforceConfig.http1Settings,
+            http2Settings: salesforceConfig.http2Settings,
+            timeout: salesforceConfig.timeout,
+            forwarded: salesforceConfig.forwarded,
+            followRedirects: salesforceConfig.followRedirects,
+            poolConfig: salesforceConfig.poolConfig,
+            cache: salesforceConfig.cache,
+            compression: salesforceConfig.compression,
+            circuitBreaker: salesforceConfig.circuitBreaker,
+            retryConfig: salesforceConfig.retryConfig,
+            cookieConfig: salesforceConfig.cookieConfig,
+            responseLimits: salesforceConfig.responseLimits
         });
 
         if (httpClientResult is http:Client) {
@@ -519,12 +532,38 @@ public isolated client class Client {
 # + baseUrl - The Salesforce endpoint URL
 # + clientConfig - OAuth2 direct token configuration
 # + secureSocketConfig - HTTPS secure socket configuration
+# + httpVersion - The HTTP version understood by the client
+# + http1Settings - Configurations related to HTTP/1.x protocol
+# + http2Settings - Configurations related to HTTP/2 protocol
+# + timeout - The maximum time to wait (in seconds) for a response before closing the connection
+# + forwarded - The choice of setting `forwarded`/`x-forwarded` header
+# + followRedirects - Configurations associated with Redirection
+# + poolConfig - Configurations associated with request pooling
+# + cache - HTTP caching related configurations
+# + compression - Specifies the way of handling compression (`accept-encoding`) header
+# + circuitBreaker - Configurations associated with the behaviour of the Circuit Breaker
+# + retryConfig - Configurations associated with retrying
+# + cookieConfig - Configurations associated with cookies
+# + responseLimits - Configurations associated with inbound response size limits
 @display {label: "Connection Config"}
-public type SalesforceConfiguration record {|
+public type ConnectionConfig record {|
     @display {label: "Salesforce Domain URL"}
     string baseUrl;
     @display {label: "Auth Config"}
     http:OAuth2RefreshTokenGrantConfig|http:BearerTokenConfig clientConfig;
     @display {label: "SSL Config"}
     http:ClientSecureSocket secureSocketConfig?;
+    string httpVersion = "1.1";
+    http:ClientHttp1Settings http1Settings = {};
+    http:ClientHttp2Settings http2Settings = {};
+    decimal timeout = 60;
+    string forwarded = "disable";
+    http:FollowRedirects? followRedirects = ();
+    http:PoolConfiguration? poolConfig = ();
+    http:CacheConfig cache = {};
+    http:Compression compression = http:COMPRESSION_AUTO;
+    http:CircuitBreakerConfig? circuitBreaker = ();
+    http:RetryConfig? retryConfig = ();
+    http:CookieConfig? cookieConfig = ();
+    http:ResponseLimitConfigs responseLimits = {};
 |};

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_delete_csv.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_delete_csv.bal
@@ -19,7 +19,7 @@ import ballerinax/sfdc;
 import ballerina/regex;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_file_insert_csv.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_file_insert_csv.bal
@@ -24,7 +24,7 @@ public function main(){
     string batchId = "";
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_insert_csv.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_insert_csv.bal
@@ -23,7 +23,7 @@ public function main(){
     string batchId = "";
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_query_csv.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_query_csv.bal
@@ -23,7 +23,7 @@ public function main(){
     string batchId = "";
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_update_csv.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_update_csv.bal
@@ -19,7 +19,7 @@ import ballerinax/sfdc;
 import ballerina/regex;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_upsert_csv.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_upsert_csv.bal
@@ -19,7 +19,7 @@ import ballerinax/sfdc;
 import ballerina/regex;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_delete_json.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_delete_json.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_file_insert_json.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_file_insert_json.bal
@@ -21,7 +21,7 @@ import ballerina/io;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_insert_json.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_insert_json.bal
@@ -22,7 +22,7 @@ public function main(){
     string batchId = "";
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_query_json.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_query_json.bal
@@ -23,7 +23,7 @@ public function main(){
     json[] jsonQueryResult = [];
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_update_json.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_update_json.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_upsert_json.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_upsert_json.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_delete_xml.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_delete_xml.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_file_insert_xml.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_file_insert_xml.bal
@@ -23,7 +23,7 @@ public function main(){
     string batchId = "";
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_insert_xml.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_insert_xml.bal
@@ -22,7 +22,7 @@ public function main(){
     string batchId = "";
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_query_xml.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_query_xml.bal
@@ -22,7 +22,7 @@ public function main(){
     string batchId = "";
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_update_xml.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_update_xml.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_upsert_xml.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_upsert_xml.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/account-related-usecases/account_create.bal
+++ b/sfdc/samples/rest_api_usecases/account-related-usecases/account_create.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main() {
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/account-related-usecases/account_delete.bal
+++ b/sfdc/samples/rest_api_usecases/account-related-usecases/account_delete.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/account-related-usecases/account_get_by_id.bal
+++ b/sfdc/samples/rest_api_usecases/account-related-usecases/account_get_by_id.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/account-related-usecases/account_update.bal
+++ b/sfdc/samples/rest_api_usecases/account-related-usecases/account_update.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/contact-related-usecases/contact_create.bal
+++ b/sfdc/samples/rest_api_usecases/contact-related-usecases/contact_create.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/contact-related-usecases/contact_delete.bal
+++ b/sfdc/samples/rest_api_usecases/contact-related-usecases/contact_delete.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/contact-related-usecases/contact_get_by_id.bal
+++ b/sfdc/samples/rest_api_usecases/contact-related-usecases/contact_get_by_id.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/contact-related-usecases/contact_update.bal
+++ b/sfdc/samples/rest_api_usecases/contact-related-usecases/contact_update.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/find_record_by_query.bal
+++ b/sfdc/samples/rest_api_usecases/find_record_by_query.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/lead-related-usecases/lead_create.bal
+++ b/sfdc/samples/rest_api_usecases/lead-related-usecases/lead_create.bal
@@ -19,7 +19,7 @@ import ballerinax/sfdc;
 
 public function main() {
 
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/lead-related-usecases/lead_delete.bal
+++ b/sfdc/samples/rest_api_usecases/lead-related-usecases/lead_delete.bal
@@ -17,7 +17,7 @@
 import ballerina/log;
 import ballerinax/sfdc;
 
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/lead-related-usecases/lead_get_by_id.bal
+++ b/sfdc/samples/rest_api_usecases/lead-related-usecases/lead_get_by_id.bal
@@ -19,7 +19,7 @@ import ballerinax/sfdc;
 
 public function main(){
 
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/lead-related-usecases/lead_update.bal
+++ b/sfdc/samples/rest_api_usecases/lead-related-usecases/lead_update.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/opportunity-related-usecases/opportunity_create.bal
+++ b/sfdc/samples/rest_api_usecases/opportunity-related-usecases/opportunity_create.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main() {
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/opportunity-related-usecases/opportunity_delete.bal
+++ b/sfdc/samples/rest_api_usecases/opportunity-related-usecases/opportunity_delete.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/opportunity-related-usecases/opportunity_get_by_id.bal
+++ b/sfdc/samples/rest_api_usecases/opportunity-related-usecases/opportunity_get_by_id.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/opportunity-related-usecases/opportunity_update.bal
+++ b/sfdc/samples/rest_api_usecases/opportunity-related-usecases/opportunity_update.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/org-metadata-usecases/get_api_version.bal
+++ b/sfdc/samples/rest_api_usecases/org-metadata-usecases/get_api_version.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/org-metadata-usecases/get_org_limits.bal
+++ b/sfdc/samples/rest_api_usecases/org-metadata-usecases/get_org_limits.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/org-metadata-usecases/get_organizational_data.bal
+++ b/sfdc/samples/rest_api_usecases/org-metadata-usecases/get_organizational_data.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/org-metadata-usecases/get_version_resources.bal
+++ b/sfdc/samples/rest_api_usecases/org-metadata-usecases/get_version_resources.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/product-related-usecases/product_create.bal
+++ b/sfdc/samples/rest_api_usecases/product-related-usecases/product_create.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main() {
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/product-related-usecases/product_delete.bal
+++ b/sfdc/samples/rest_api_usecases/product-related-usecases/product_delete.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/product-related-usecases/product_get_by_Id.bal
+++ b/sfdc/samples/rest_api_usecases/product-related-usecases/product_get_by_Id.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/product-related-usecases/product_update.bal
+++ b/sfdc/samples/rest_api_usecases/product-related-usecases/product_update.bal
@@ -18,7 +18,7 @@ import ballerina/log;
 import ballerinax/sfdc;
 
 // Create Salesforce client configuration by reading from config file.
-sfdc:SalesforceConfiguration sfConfig = {
+sfdc:ConnectionConfig sfConfig = {
     baseUrl: "<BASE_URL>",
     clientConfig: {
         clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/search_record_by_string.bal
+++ b/sfdc/samples/rest_api_usecases/search_record_by_string.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/sobject-metadata-usecases/describe_available_objects.bal
+++ b/sfdc/samples/rest_api_usecases/sobject-metadata-usecases/describe_available_objects.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/sobject-metadata-usecases/describe_sobject.bal
+++ b/sfdc/samples/rest_api_usecases/sobject-metadata-usecases/describe_sobject.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/sobject-metadata-usecases/get_sobject_info.bal
+++ b/sfdc/samples/rest_api_usecases/sobject-metadata-usecases/get_sobject_info.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/sobject-metadata-usecases/get_sobject_platformAction.bal
+++ b/sfdc/samples/rest_api_usecases/sobject-metadata-usecases/get_sobject_platformAction.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/sobject_create.bal
+++ b/sfdc/samples/rest_api_usecases/sobject_create.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/sobject_delete.bal
+++ b/sfdc/samples/rest_api_usecases/sobject_delete.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/sobject_get_by_id.bal
+++ b/sfdc/samples/rest_api_usecases/sobject_get_by_id.bal
@@ -19,7 +19,7 @@ import ballerinax/sfdc;
 public function main() {
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/sobject_get_record.bal
+++ b/sfdc/samples/rest_api_usecases/sobject_get_record.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/sobject_update.bal
+++ b/sfdc/samples/rest_api_usecases/sobject_update.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/samples/rest_api_usecases/sojbect_get_record_by_ext.bal
+++ b/sfdc/samples/rest_api_usecases/sojbect_get_record_by_ext.bal
@@ -20,7 +20,7 @@ import ballerinax/sfdc;
 public function main(){
 
     // Create Salesforce client configuration by reading from config file.
-    sfdc:SalesforceConfiguration sfConfig = {
+    sfdc:ConnectionConfig sfConfig = {
         baseUrl: "<BASE_URL>",
         clientConfig: {
             clientId: "<CLIENT_ID>",

--- a/sfdc/tests/rest_api_test.bal
+++ b/sfdc/tests/rest_api_test.bal
@@ -26,7 +26,7 @@ configurable string & readonly refreshUrl = os:getEnv("REFRESH_URL");
 configurable string & readonly baseUrl = os:getEnv("EP_URL");
 
 // Using direct-token config for client configuration
-SalesforceConfiguration sfConfig = {
+ConnectionConfig sfConfig = {
     baseUrl: baseUrl,
     clientConfig: {
         clientId: clientId,


### PR DESCRIPTION
## Purpose
- Change connector configuration record name to `ConnectionConfig`
- Add support for all `http:ClientConfiguration` fields in the connector configuration

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3
