### PR TITLE
Fix intermittent test case failures

### DIFF
--- a/sfdc/modules/bulk/data_mappings.bal
+++ b/sfdc/modules/bulk/data_mappings.bal
@@ -89,6 +89,7 @@ isolated function createBatchResultRecordFromXml(xml payload) returns Result[]|e
     xmlns "http://www.force.com/2009/06/asyncapi/dataload" as ns;
     foreach var result in payload/<*> {
         Result batchResult = {
+            id: (result/<ns:id>/*).toString(),
             success: getBooleanValue((result/<ns:success>/*).toString()),
             created: getBooleanValue((result/<ns:created>/*).toString())
         };

--- a/sfdc/modules/bulk/tests/bulk_csv_delete.bal
+++ b/sfdc/modules/bulk/tests/bulk_csv_delete.bal
@@ -19,125 +19,115 @@ import ballerina/test;
 import ballerina/lang.runtime;
 
 @test:AfterSuite {}
-function deleteCsv() {
+function deleteCsv() returns error? {
     log:printInfo("baseClient -> deleteCsv");
     string batchId = "";
-    string contacts = getCsvContactsToDelete(csvQueryResult);
 
     //create job
-    error|BulkJob deleteJob = baseClient->createJob("delete", "Contact", "CSV");
+    BulkJob deleteJob = check baseClient->createJob("delete", "Contact", "CSV");
 
-    if (deleteJob is BulkJob) {
-        //add csv content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(deleteJob, <@untainted>contacts);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts to delete using CSV.");
-                batchId = batch.id;
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
-            }
-        }
-
-        //get job info
-        error|JobInfo jobInfo = baseClient->getJobInfo(deleteJob);
-        if (jobInfo is JobInfo) {
-            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    //add csv content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(deleteJob, csvInputResult);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts to delete using CSV.");
+            batchId = batch.id;
+            break;
         } else {
-            test:assertFail(msg = jobInfo.message());
-        }
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(deleteJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
-
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(deleteJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
-
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(deleteJob, batchId);
-            if (batchRequest is string) {
-                test:assertTrue(checkCsvResult(batchRequest) == 4, msg = "Retrieving batch request failed.");
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
-            } else {
-                test:assertFail(msg = "Invalid Batch Request!");
-                break;
-            }
-        }
-
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(deleteJob, batchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-            }
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(deleteJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-        } else {
-            test:assertFail(msg = closedJob.message());
-        }
-
-    } else {
-        test:assertFail(msg = deleteJob.message());
     }
+
+    //get job info
+    error|JobInfo jobInfo = baseClient->getJobInfo(deleteJob);
+    if (jobInfo is JobInfo) {
+        test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    } else {
+        test:assertFail(msg = jobInfo.message());
+    }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(deleteJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(deleteJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
+            }
+        }
+    }
+
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(deleteJob, batchId);
+        if (batchRequest is string) {
+            test:assertTrue(checkCsvResult(batchRequest) == 4, msg = "Retrieving batch request failed.");
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
+            break;
+        }
+    }
+
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(deleteJob, batchId);
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            foreach Result res in batchResult {
+                test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
+            }
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+        }
+    }
+
+    //close job
+    JobInfo closedJob = check baseClient->closeJob(deleteJob);
+    test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
 }

--- a/sfdc/modules/bulk/tests/bulk_csv_insert.bal
+++ b/sfdc/modules/bulk/tests/bulk_csv_insert.bal
@@ -19,13 +19,13 @@ import ballerina/log;
 import ballerina/test;
 import ballerina/lang.runtime;
 
-int maxIterations = 5;
-decimal delayInSecs = 5.0;
+const int maxIterations = 5;
+const decimal delayInSecs = 5.0;
 
 @test:Config {
     enable: true
 }
-function insertCsv() {
+function insertCsv() returns error? {
     log:printInfo("baseClient -> insertCsv");
     string batchId = "";
     string contacts = "description,FirstName,LastName,Title,Phone,Email,My_External_Id__c\n"
@@ -33,138 +33,139 @@ function insertCsv() {
         + "Created_from_Ballerina_Sf_Bulk_API,Burbage,Shane,Professor Level 02,0332211777,peter77@gmail.com,846";
 
     //create job
-    error|BulkJob insertJob = baseClient->createJob("insert", "Contact", "CSV");
+    BulkJob insertJob = check baseClient->createJob("insert", "Contact", "CSV");
 
-    if (insertJob is BulkJob) {
-        //add csv content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(insertJob, contacts);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using CSV.");
-                batchId = batch.id;
-                break;
+    //add csv content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(insertJob, contacts);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using CSV.");
+            batchId = batch.id;
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
+    }
 
-        //get job info
-        foreach var i in 1 ..< maxIterations {
-            error|JobInfo jobInfo = baseClient->getJobInfo(insertJob);
-            if (jobInfo is JobInfo) {
-                test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
-                break;
+    //get job info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|JobInfo jobInfo = baseClient->getJobInfo(insertJob);
+        if (jobInfo is JobInfo) {
+            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getJobInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getJobInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getJobInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = jobInfo.message());
-                }
+                log:printWarn("getJobInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = jobInfo.message());
             }
         }
+    }
 
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(insertJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(insertJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
             }
         }
-        
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(insertJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
+    }
 
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(insertJob, batchId);
-            if (batchRequest is string) {
-                test:assertTrue(checkCsvResult(batchRequest) == 2, msg = "Retrieving batch request failed.");
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(insertJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                test:assertFail(msg = "Invalid Batch Request!");
-                break;
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
             }
         }
-        
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(insertJob, batchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-                break;
-            }
-        }
+    }
 
-        //close job
-        foreach var i in 1 ..< maxIterations {
-            error|JobInfo closedJob = baseClient->closeJob(insertJob);
-            if (closedJob is JobInfo) {
-                test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-                break;
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(insertJob, batchId);
+        if (batchRequest is string) {
+            test:assertTrue(checkCsvResult(batchRequest) == 2, msg = "Retrieving batch request failed.");
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("closeJob Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("closeJob Operation Failed! Giving up...");
-                    test:assertFail(msg = closedJob.message());
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
+            break;
+        }
+    }
+
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(insertJob, batchId);
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            foreach var item in batchResult {
+                json|error itemId = item?.id;
+                if (itemId is json) {
+                    string id = itemId.toString();
+                    csvInputResult = csvInputResult + "\n" + id;
                 }
+                test:assertTrue(checkBatchResults(item), msg = item?.errors.toString());
+            }
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+            break;
+        }
+    }
+
+    //close job
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|JobInfo closedJob = baseClient->closeJob(insertJob);
+        if (closedJob is JobInfo) {
+            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("closeJob Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("closeJob Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = closedJob.message());
             }
         }
-    } else {
-        test:assertFail(msg = insertJob.message());
     }
 }
 
@@ -184,10 +185,11 @@ function insertCsvFromFile() {
         //add csv content via file
         io:ReadableByteChannel|io:Error rbc = io:openReadableFile(csvContactsFilePath);
         if (rbc is io:ReadableByteChannel) {
-            foreach var i in 1 ..< maxIterations {
+            foreach var i in 1 ..< maxIterations + 1 {
                 error|BatchInfo batchUsingCsvFile = baseClient->addBatch(insertJob, <@untainted>rbc);
                 if (batchUsingCsvFile is BatchInfo) {
-                    test:assertTrue(batchUsingCsvFile.id.length() > 0, msg = "Could not upload the contacts using CSV file.");
+                    test:assertTrue(batchUsingCsvFile.id.length() > 0, 
+                    msg = "Could not upload the contacts using CSV file.");
                     batchId = batchUsingCsvFile.id;
                     break;
                 } else {
@@ -195,7 +197,7 @@ function insertCsvFromFile() {
                         log:printWarn("addBatch Operation Failed! Retrying...");
                         runtime:sleep(delayInSecs);
                     } else {
-                        log:printWarn("addBatch Operation Failed! Giving up...");
+                        log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
                         test:assertFail(msg = batchUsingCsvFile.message());
                     }
                 }
@@ -207,7 +209,7 @@ function insertCsvFromFile() {
         }
 
         //get job info
-        foreach var i in 1 ..< maxIterations {
+        foreach var i in 1 ..< maxIterations + 1 {
             error|JobInfo jobInfo = baseClient->getJobInfo(insertJob);
             if (jobInfo is JobInfo) {
                 test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
@@ -216,14 +218,14 @@ function insertCsvFromFile() {
                     log:printWarn("getJobInfo Operation Failed! Retrying...");
                     runtime:sleep(delayInSecs);
                 } else {
-                    log:printWarn("getJobInfo Operation Failed! Giving up...");
+                    log:printWarn("getJobInfo Operation Failed! Giving up after 5 tries.");
                     test:assertFail(msg = jobInfo.message());
                 }
             }
         }
 
         //get batch info
-        foreach var i in 1 ..< maxIterations {
+        foreach var i in 1 ..< maxIterations + 1 {
             error|BatchInfo batchInfo = baseClient->getBatchInfo(insertJob, batchId);
             if (batchInfo is BatchInfo) {
                 test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
@@ -232,14 +234,14 @@ function insertCsvFromFile() {
                     log:printWarn("getBatchInfo Operation Failed! Retrying...");
                     runtime:sleep(delayInSecs);
                 } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
+                    log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
                     test:assertFail(msg = batchInfo.message());
                 }
             }
         }
-        
+
         //get all batches
-        foreach var i in 1 ..< maxIterations {
+        foreach var i in 1 ..< maxIterations + 1 {
             error|BatchInfo[] batchInfoList = baseClient->getAllBatches(insertJob);
             if (batchInfoList is BatchInfo[]) {
                 test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
@@ -248,14 +250,14 @@ function insertCsvFromFile() {
                     log:printWarn("getAllBatches Operation Failed! Retrying...");
                     runtime:sleep(delayInSecs);
                 } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
+                    log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
                     test:assertFail(msg = batchInfoList.message());
                 }
             }
         }
 
         //get batch request
-        foreach var i in 1 ..< maxIterations {
+        foreach var i in 1 ..< maxIterations + 1 {
             var batchRequest = baseClient->getBatchRequest(insertJob, batchId);
             if (batchRequest is string) {
                 test:assertTrue(checkCsvResult(batchRequest) == 2, msg = "Retrieving batch request failed.");
@@ -265,7 +267,7 @@ function insertCsvFromFile() {
                     log:printWarn("getBatchRequest Operation Failed! Retrying...");
                     runtime:sleep(delayInSecs);
                 } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
+                    log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
                     test:assertFail(msg = batchRequest.message());
                 }
             } else {
@@ -275,20 +277,25 @@ function insertCsvFromFile() {
         }
 
 
-        foreach var i in 1 ..< maxIterations {
+        foreach var i in 1 ..< maxIterations + 1 {
             var batchResult = baseClient->getBatchResult(insertJob, batchId);
             if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
+                foreach var item in batchResult {
+                    json|error itemId = item?.id;
+                    if (itemId is json) {
+                        string id = itemId.toString();
+                        csvInputResult = csvInputResult + "\n" + id;
+                    }
+                    test:assertTrue(checkBatchResults(item), msg = item?.errors.toString());
+                }
+                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");              
                 break;
             } else if (batchResult is error) {
                 if i != 5 {
                     log:printWarn("getBatchResult Operation Failed! Retrying...");
                     runtime:sleep(delayInSecs);
                 } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
+                    log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
                     test:assertFail(msg = batchResult.message());
                 }
             } else {

--- a/sfdc/modules/bulk/tests/bulk_csv_query.bal
+++ b/sfdc/modules/bulk/tests/bulk_csv_query.bal
@@ -22,134 +22,129 @@ import ballerina/lang.runtime;
     enable: true,
     dependsOn: [updateCsv, insertCsvFromFile, insertCsv]
 }
-function queryCsv() {
+function queryCsv() returns error? {
+    runtime:sleep(delayInSecs);
     log:printInfo("baseClient -> queryCsv");
     string batchId = "";
     string queryStr = "SELECT Id, Name FROM Contact WHERE Title='Professor Level 02'";
 
     //create job
-    error|BulkJob queryJob = baseClient->createJob("query", "Contact", "CSV");
+    BulkJob queryJob = check baseClient->createJob("query", "Contact", "CSV");
 
-    if (queryJob is BulkJob) {
-        //add query string
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(queryJob, queryStr);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not add batch.");
-                batchId = batch.id;
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
-            }
-        }
-
-        //get job info
-        foreach var i in 1 ..< maxIterations {
-            error|JobInfo jobInfo = baseClient->getJobInfo(queryJob);
-            if (jobInfo is JobInfo) {
-                test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getJobInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getJobInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = jobInfo.message());
-                }
-            }
-        }       
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(queryJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
-            }
-        }
-
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(queryJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
-
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(queryJob, batchId);
-            if (batchRequest is string) {
-                test:assertTrue(batchRequest.startsWith("SELECT"), msg = "Retrieving batch request failed.");
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
-            } else {
-                test:assertFail(msg = "Invalid Batch Request!");
-                break;
-            }
-        }
-
-        //get batch result
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(queryJob, batchId);
-            if (batchResult is string) {
-                //io:println("count : ", checkCsvResult(batchResult).toString());
-                test:assertTrue(checkCsvResult(batchResult) == 4, msg = "Retrieving batch result failed.");
-                csvQueryResult = <@untainted>batchResult;
-                break;  
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-                break;
-            }   
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(queryJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
+    //add query string
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(queryJob, queryStr);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not add batch.");
+            batchId = batch.id;
+            break;
         } else {
-            test:assertFail(msg = closedJob.message());
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
+            }
         }
+    }
+
+    //get job info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|JobInfo jobInfo = baseClient->getJobInfo(queryJob);
+        if (jobInfo is JobInfo) {
+            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getJobInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getJobInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = jobInfo.message());
+            }
+        }
+    }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(queryJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(queryJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
+            }
+        }
+    }
+
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(queryJob, batchId);
+        if (batchRequest is string) {
+            test:assertTrue(batchRequest.startsWith("SELECT"), msg = "Retrieving batch request failed.");
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
+            break;
+        }
+    }
+
+    //get batch result
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(queryJob, batchId);
+        if (batchResult is string) {
+            test:assertTrue(checkCsvResult(batchResult) == 4, msg = "Retrieving batch result failed.");
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+            break;
+        }
+    }
+
+    //close job
+    error|JobInfo closedJob = baseClient->closeJob(queryJob);
+    if (closedJob is JobInfo) {
+        test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
     } else {
-        test:assertFail(msg = queryJob.message());
+        test:assertFail(msg = closedJob.message());
     }
 }

--- a/sfdc/modules/bulk/tests/bulk_csv_update.bal
+++ b/sfdc/modules/bulk/tests/bulk_csv_update.bal
@@ -22,139 +22,130 @@ import ballerina/lang.runtime;
     enable: true,
     dependsOn: [insertCsv, upsertCsv]
 }
-function updateCsv() {
+function updateCsv() returns error? {
     log:printInfo("baseClient -> updateCsv");
     string batchId = "";
     string binnsID = getContactIdByName("Cuthbert", "Binns", "Professor Level 02");
     string shanesID = getContactIdByName("Burbage", "Shane", "Professor Level 02");
-    string contacts = "Id,description,FirstName,LastName,Title,Phone,Email,My_External_Id__c\n" + binnsID
-        + ",Created_from_Ballerina_Sf_Bulk_API,Cuthbert,Binns,Professor Level 02,0222236677,bins98@gmail.com,845\n"
+    string contacts = "Id,description,FirstName,LastName,Title,Phone,Email,My_External_Id__c\n" + binnsID 
+        + ",Created_from_Ballerina_Sf_Bulk_API,Cuthbert,Binns,Professor Level 02,0222236677,bins98@gmail.com,845\n" 
         + shanesID + ",Created_from_Ballerina_Sf_Bulk_API,Burbage,Shane,Professor Level 02,0332211788,shane78@gmail.com,846";
 
     //create job
-    error|BulkJob updateJob = baseClient->createJob("update", "Contact", "CSV");
+    BulkJob updateJob = check baseClient->createJob("update", "Contact", "CSV");
 
-    if (updateJob is BulkJob) {
-        //add csv content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using CSV.");
-                batchId = batch.id;
-                break;
+    //add csv content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using CSV.");
+            batchId = batch.id;
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
+    }
 
-        //get job info
-        foreach var i in 1 ..< maxIterations {
-            error|JobInfo jobInfo = baseClient->getJobInfo(updateJob);
-            if (jobInfo is JobInfo) {
-                test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
-                break;
+    //get job info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|JobInfo jobInfo = baseClient->getJobInfo(updateJob);
+        if (jobInfo is JobInfo) {
+            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getJobInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getJobInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getJobInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = jobInfo.message());
-                }
+                log:printWarn("getJobInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = jobInfo.message());
             }
         }
+    }
 
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(updateJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(updateJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
             }
         }
+    }
 
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(updateJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(updateJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
             }
         }
+    }
 
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(updateJob, batchId);
-            if (batchRequest is string) {
-                test:assertTrue(checkCsvResult(batchRequest) == 2, msg = "Retrieving batch request failed.");
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(updateJob, batchId);
+        if (batchRequest is string) {
+            test:assertTrue(checkCsvResult(batchRequest) == 2, msg = "Retrieving batch request failed.");
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                test:assertFail(msg = "Invalid Batch Request!");
-                break;
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
             }
-        }
-
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(updateJob, batchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                    } else {
-                        log:printWarn("getAllBatches Operation Failed! Giving up...");
-                        test:assertFail(msg = batchResult.message());
-                    }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-            }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
             break;
         }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(updateJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-        } else {
-            test:assertFail(msg = closedJob.message());
-        }
-
-    } else {
-        test:assertFail(msg = updateJob.message());
     }
+
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(updateJob, batchId);
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            foreach Result res in batchResult {
+                test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
+            }
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+        }
+        break;
+    }
+
+    //close job
+    JobInfo closedJob = check baseClient->closeJob(updateJob);
+    test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
 }

--- a/sfdc/modules/bulk/tests/bulk_csv_upsert.bal
+++ b/sfdc/modules/bulk/tests/bulk_csv_upsert.bal
@@ -22,136 +22,131 @@ import ballerina/lang.runtime;
     enable: true,
     dependsOn: [insertCsv]
 }
-function upsertCsv() {
+function upsertCsv() returns error? {
     log:printInfo("baseClient -> upsertCsv");
     string batchId = "";
-    string contacts = "description,FirstName,LastName,Title,Phone,Email,My_External_Id__c\n"
-        + "Created_from_Ballerina_Sf_Bulk_API,Cuthbert,Binns,Professor Level 02,0332236677,bins98@gmail.com,845\n"
+    string contacts = "description,FirstName,LastName,Title,Phone,Email,My_External_Id__c\n" 
+        + "Created_from_Ballerina_Sf_Bulk_API,Cuthbert,Binns,Professor Level 02,0332236677,bins98@gmail.com,845\n" 
         + "Created_from_Ballerina_Sf_Bulk_API,Burbage,Shane,Professor Level 02,0332211777,shane78@gmail.com,846";
 
     //create job
-    error|BulkJob upsertJob = baseClient->createJob("upsert", "Contact", "CSV", "My_External_Id__c");
+    BulkJob upsertJob = check baseClient->createJob("upsert", "Contact", "CSV", "My_External_Id__c");
 
-    if (upsertJob is BulkJob) {
-        //add csv content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(upsertJob, contacts);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using CSV.");
-                batchId = batch.id;
-                break;
+    //add csv content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(upsertJob, contacts);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using CSV.");
+            batchId = batch.id;
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
+    }
 
-        //get job info
-        foreach var i in 1 ..< maxIterations {
-            error|JobInfo jobInfo = baseClient->getJobInfo(upsertJob);
-            if (jobInfo is JobInfo) {
-                test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
-                break;
+    //get job info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|JobInfo jobInfo = baseClient->getJobInfo(upsertJob);
+        if (jobInfo is JobInfo) {
+            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getJobInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getJobInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getJobInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = jobInfo.message());
-                }
+                log:printWarn("getJobInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = jobInfo.message());
             }
         }
+    }
 
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(upsertJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(upsertJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
             }
         }
+    }
 
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(upsertJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(upsertJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
             }
         }
+    }
 
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(upsertJob, batchId);
-            if (batchRequest is string) {
-                test:assertTrue(checkCsvResult(batchRequest) == 2, msg = "Retrieving batch request failed.");
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(upsertJob, batchId);
+        if (batchRequest is string) {
+            test:assertTrue(checkCsvResult(batchRequest) == 2, msg = "Retrieving batch request failed.");
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                test:assertFail(msg = "Invalid Batch Request!");
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
             }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
         }
+    }
 
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(upsertJob, batchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(upsertJob, batchId);
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            foreach Result res in batchResult {
+                test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
             }
             break;
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(upsertJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
         } else {
-            test:assertFail(msg = closedJob.message());
+            test:assertFail("Invalid Batch Result!");
         }
+        break;
+    }
 
+    //close job
+    error|JobInfo closedJob = baseClient->closeJob(upsertJob);
+    if (closedJob is JobInfo) {
+        test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
     } else {
-        test:assertFail(msg = upsertJob.message());
+        test:assertFail(msg = closedJob.message());
     }
 }

--- a/sfdc/modules/bulk/tests/bulk_json_delete.bal
+++ b/sfdc/modules/bulk/tests/bulk_json_delete.bal
@@ -19,130 +19,126 @@ import ballerina/test;
 import ballerina/lang.runtime;
 
 @test:AfterSuite {}
-function deleteJson() {
+function deleteJson() returns error? {
     log:printInfo("baseClient -> deleteJson");
     string batchId = "";
-    json contacts = getJsonContactsToDelete(jsonQueryResult);
+    json contacts = getJsonContactsToDelete(jsonInsertResult);
 
     //create job
-    error|BulkJob deleteJob = baseClient->createJob("delete", "Contact", "JSON");
+    BulkJob deleteJob = check baseClient->createJob("delete", "Contact", "JSON");
 
-    if (deleteJob is BulkJob) {
-        //add json content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(deleteJob, contacts);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts to delete using json.");
-                batchId = batch.id;
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
-            }
-        }
-
-        //get job info
-        error|JobInfo jobInfo = baseClient->getJobInfo(deleteJob);
-        if (jobInfo is JobInfo) {
-            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    //add json content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(deleteJob, contacts);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts to delete using json.");
+            batchId = batch.id;
+            break;
         } else {
-            test:assertFail(msg = jobInfo.message());
-        }
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(deleteJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
+    }
 
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(deleteJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
-
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(deleteJob, batchId);
-            if (batchRequest is json) {
-                json[]|error batchRequestArr = <json[]>batchRequest;
-                if (batchRequestArr is json[]) {
-                    test:assertTrue(batchRequestArr.length() == 4, msg = "Retrieving batch request failed.");
-                } else {
-                    test:assertFail(msg = batchRequestArr.toString());
-                }
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
-            } else {
-                test:assertFail(msg = "Invalid Batch Request!");
-                break;
-            }
-        }
-
-        //get batch result
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(deleteJob, batchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-            }
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(deleteJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-        } else {
-            test:assertFail(msg = closedJob.message());
-        }
+    //get job info
+    error|JobInfo jobInfo = baseClient->getJobInfo(deleteJob);
+    if (jobInfo is JobInfo) {
+        test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
     } else {
-        test:assertFail(msg = deleteJob.message());
+        test:assertFail(msg = jobInfo.message());
+    }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(deleteJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(deleteJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
+            }
+        }
+    }
+
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(deleteJob, batchId);
+        if (batchRequest is json) {
+            json[]|error batchRequestArr = <json[]>batchRequest;
+            if (batchRequestArr is json[]) {
+                test:assertTrue(batchRequestArr.length() == 4, msg = "Retrieving batch request failed.");
+            } else {
+                test:assertFail(msg = batchRequestArr.toString());
+            }
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
+            break;
+        }
+    }
+
+    //get batch result
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(deleteJob, batchId);
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            foreach Result res in batchResult {
+                test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
+            }
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+        }
+    }
+
+    //close job
+    error|JobInfo closedJob = baseClient->closeJob(deleteJob);
+    if (closedJob is JobInfo) {
+        test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
+    } else {
+        test:assertFail(msg = closedJob.message());
     }
 }

--- a/sfdc/modules/bulk/tests/bulk_json_insert.bal
+++ b/sfdc/modules/bulk/tests/bulk_json_insert.bal
@@ -22,7 +22,7 @@ import ballerina/lang.runtime;
 @test:Config {
     enable: true
 }
-function insertJson() {
+function insertJson() returns error? {
     log:printInfo("baseClient -> insertJson");
     string jsonBatchId = "";
 
@@ -45,286 +45,274 @@ function insertJson() {
     }];
 
     //create job
-    error|BulkJob jsonInsertJob = baseClient->createJob("insert", "Contact", "JSON");
+    BulkJob jsonInsertJob = check baseClient->createJob("insert", "Contact", "JSON");
 
-    if (jsonInsertJob is BulkJob) {
-        //add json content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(jsonInsertJob, contacts);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using json.");
-                jsonBatchId = batch.id;
+    //add json content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(jsonInsertJob, contacts);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using json.");
+            jsonBatchId = batch.id;
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
+            }
+        }
+    }
+
+    //get job info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|JobInfo jobInfo = baseClient->getJobInfo(jsonInsertJob);
+
+        if (jobInfo is JobInfo) {
+            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getJobInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getJobInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = jobInfo.message());
+            }
+        }
+    }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(jsonInsertJob, jsonBatchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == jsonBatchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< 3 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(jsonInsertJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i == 2 {
+                test:assertFail(msg = batchInfoList.message());
+            } else {
+                log:printInfo("Batch Operation Failed! Retrying...");
+                runtime:sleep(5.0);
+            }
+        }
+    }
+
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(jsonInsertJob, jsonBatchId);
+        if (batchRequest is json) {
+            json[]|error batchRequestArr = <json[]>batchRequest;
+            if (batchRequestArr is json[]) {
+                test:assertTrue(batchRequestArr.length() == 2, msg = "Retrieving batch request failed.");
+            } else {
+                test:assertFail(msg = batchRequestArr.toString());
+            }
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
+            break;
+        }
+    }
+
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(jsonInsertJob, jsonBatchId);
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            foreach json res in batchResult {
+                jsonInsertResult.push(res);
+                test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
+            }
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+            break;
+        }
+    }
+
+    //close job
+    foreach var i in 1 ..< maxIterations + 1 {
+
+        error|JobInfo closedJob = baseClient->closeJob(jsonInsertJob);
+        if (closedJob is JobInfo) {
+            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("closeJob Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("closeJob Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = closedJob.message());
+            }
+        }
+    }
+}
+
+@test:Config {enable: true}
+function insertJsonFromFile() returns error? {
+    log:printInfo("baseClient -> insertJsonFromFile");
+    string jsonBatchId = "";
+    string jsonContactsFilePath = "sfdc/modules/bulk/tests/resources/contacts.json";
+
+    //create job
+    BulkJob jsonInsertJob = check baseClient->createJob("insert", "Contact", "JSON");
+
+    //add json content
+    io:ReadableByteChannel|io:Error rbc = io:openReadableFile(jsonContactsFilePath);
+    if (rbc is io:ReadableByteChannel) {
+        foreach var i in 1 ..< maxIterations + 1 {
+            error|BatchInfo batchUsingJsonFile = baseClient->addBatch(jsonInsertJob, <@untainted>rbc);
+            if (batchUsingJsonFile is BatchInfo) {
+                test:assertTrue(batchUsingJsonFile.id.length() > 0, 
+                    msg = "Could not upload the contacts using json file.");
+                jsonBatchId = batchUsingJsonFile.id;
                 break;
             } else {
                 if i != 5 {
                     log:printWarn("addBatch Operation Failed! Retrying...");
                     runtime:sleep(delayInSecs);
                 } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
+                    log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                    test:assertFail(msg = batchUsingJsonFile.message());
                 }
             }
         }
-
-        //get job info
-        foreach var i in 1 ..< maxIterations {
-            error|JobInfo jobInfo = baseClient->getJobInfo(jsonInsertJob);
-
-            if (jobInfo is JobInfo) {
-                test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getJobInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getJobInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = jobInfo.message());
-                }
-            }
-        }
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(jsonInsertJob, jsonBatchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == jsonBatchId, msg = "Getting batch info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
-            }
-        }
-        
-        //get all batches
-        foreach var i in 1 ..< 3 {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(jsonInsertJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i == 2 {
-                    test:assertFail(msg = batchInfoList.message());
-                } else {
-                    log:printInfo("Batch Operation Failed! Retrying...");
-                    runtime:sleep(5.0);
-                }
-            }
-        }
-
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(jsonInsertJob, jsonBatchId);
-            if (batchRequest is json) {
-                json[]|error batchRequestArr = <json[]>batchRequest;
-                if (batchRequestArr is json[]) {
-                    test:assertTrue(batchRequestArr.length() == 2, msg = "Retrieving batch request failed.");
-                } else {
-                    test:assertFail(msg = batchRequestArr.toString());
-                }
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
-            } else {
-                test:assertFail(msg = "Invalid Batch Request!");
-                break;
-            }
-        }
-        
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(jsonInsertJob, jsonBatchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-                break;
-            }
-        }
-        
-        //close job
-        foreach var i in 1 ..< maxIterations {
-
-            error|JobInfo closedJob = baseClient->closeJob(jsonInsertJob);
-            if (closedJob is JobInfo) {
-                test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("closeJob Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("closeJob Operation Failed! Giving up...");
-                    test:assertFail(msg = closedJob.message());
-                }
-            }
-        }
+        // close channel.
+        closeRb(rbc);
     } else {
-        test:assertFail(msg = jsonInsertJob.message());
+        test:assertFail(msg = rbc.message());
     }
-}
 
-@test:Config {
-    enable: true
-}
-function insertJsonFromFile() {
-    log:printInfo("baseClient -> insertJsonFromFile");
-    string jsonBatchId = "";
-    string jsonContactsFilePath = "sfdc/modules/bulk/tests/resources/contacts.json";
-
-    //create job
-    error|BulkJob jsonInsertJob = baseClient->createJob("insert", "Contact", "JSON");
-
-    if (jsonInsertJob is BulkJob) {
-        //add json content
-        io:ReadableByteChannel|io:Error rbc = io:openReadableFile(jsonContactsFilePath);
-        if (rbc is io:ReadableByteChannel) {
-            foreach var i in 1 ..< maxIterations {
-                error|BatchInfo batchUsingJsonFile = baseClient->addBatch(jsonInsertJob, <@untainted>rbc);
-                if (batchUsingJsonFile is BatchInfo) {
-                    test:assertTrue(batchUsingJsonFile.id.length() > 0, msg = "Could not upload the contacts using json file.");
-                    jsonBatchId = batchUsingJsonFile.id;
-                    break;
-                } else {
-                    if i != 5 {
-                        log:printWarn("addBatch Operation Failed! Retrying...");
-                        runtime:sleep(delayInSecs);
-                    } else {
-                        log:printWarn("addBatch Operation Failed! Giving up...");
-                        test:assertFail(msg = batchUsingJsonFile.message());
-                    }
-                }
-            }
-            // close channel.
-            closeRb(rbc);
+    //get job info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|JobInfo jobInfo = baseClient->getJobInfo(jsonInsertJob);
+        if (jobInfo is JobInfo) {
+            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
         } else {
-            test:assertFail(msg = rbc.message());
-        }
-
-        //get job info
-        foreach var i in 1 ..< maxIterations {
-            error|JobInfo jobInfo = baseClient->getJobInfo(jsonInsertJob);
-            if (jobInfo is JobInfo) {
-                test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+            if i != 5 {
+                log:printWarn("getJobInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getJobInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getJobInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = jobInfo.message());
-                }
+                log:printWarn("getJobInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = jobInfo.message());
             }
         }
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(jsonInsertJob, jsonBatchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == jsonBatchId, msg = "Getting batch info failed.");
-            } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
-            }
-        }
-        
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(jsonInsertJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
-
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(jsonInsertJob, jsonBatchId);
-            if (batchRequest is json) {
-                json[]|error batchRequestArr = <json[]>batchRequest;
-                if (batchRequestArr is json[]) {
-                    test:assertTrue(batchRequestArr.length() == 2, msg = "Retrieving batch request failed.");
-                } else {
-                    test:assertFail(msg = batchRequestArr.toString());
-                }
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
-            } else {
-                test:assertFail(msg = "Invalid Batch Request!");
-                break;
-            }
-        }
-
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(jsonInsertJob, jsonBatchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-            }
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(jsonInsertJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-        } else {
-            test:assertFail(msg = closedJob.message());
-        }
-    } else {
-        test:assertFail(msg = jsonInsertJob.message());
     }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(jsonInsertJob, jsonBatchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == jsonBatchId, msg = "Getting batch info failed.");
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(jsonInsertJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
+            }
+        }
+    }
+
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(jsonInsertJob, jsonBatchId);
+        if (batchRequest is json) {
+            json[]|error batchRequestArr = <json[]>batchRequest;
+            if (batchRequestArr is json[]) {
+                test:assertTrue(batchRequestArr.length() == 2, msg = "Retrieving batch request failed.");
+            } else {
+                test:assertFail(msg = batchRequestArr.toString());
+            }
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
+            break;
+        }
+    }
+
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(jsonInsertJob, jsonBatchId);
+        if (batchResult is Result[]) {
+            foreach json res in batchResult {
+                jsonInsertResult.push(res);
+            }
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+        }
+    }
+
+    //close job
+    JobInfo closedJob = check baseClient->closeJob(jsonInsertJob);
+    test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
 }

--- a/sfdc/modules/bulk/tests/bulk_json_query.bal
+++ b/sfdc/modules/bulk/tests/bulk_json_query.bal
@@ -22,128 +22,120 @@ import ballerina/lang.runtime;
     enable: true,
     dependsOn: [updateJson, insertJsonFromFile]
 }
-function queryJson() {
+function queryJson() returns error? {
+    runtime:sleep(delayInSecs);
     log:printInfo("baseClient -> queryJson");
     string batchId = "";
     string queryStr = "SELECT Id, Name FROM Contact WHERE Title='Professor Level 03'";
+
     //create job
-    error|BulkJob queryJob = baseClient->createJob("query", "Contact", "JSON");
+    BulkJob queryJob = check baseClient->createJob("query", "Contact", "JSON");
 
-    if (queryJob is BulkJob) {
-        //add query string
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(queryJob, queryStr);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not add batch.");
-                batchId = batch.id;
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
-            }
-        }
-
-        //get job info
-        error|JobInfo jobInfo = baseClient->getJobInfo(queryJob);
-        if (jobInfo is JobInfo) {
-            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    //add query string
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(queryJob, queryStr);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not add batch.");
+            batchId = batch.id;
+            break;
         } else {
-            test:assertFail(msg = jobInfo.message());
-        }
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(queryJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
-
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(queryJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
-
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(queryJob, batchId);
-            if (batchRequest is string) {
-                test:assertTrue(batchRequest.startsWith("SELECT"), msg = "Retrieving batch request failed.");
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
-            } else {
-                test:assertFail(msg = "Invalid Batch Request!");
-                break;
-            }
-        }
-
-        //get batch result
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(queryJob, batchId);
-            if (batchResult is json) {
-                json[]|error batchResultArr = <json[]>batchResult;
-                if (batchResultArr is json[]) {
-                    jsonQueryResult = <@untainted>batchResultArr;
-                    //io:println("count : " + batchResultArr.length().toString());
-                    test:assertTrue(batchResultArr.length() == 4, msg = "Retrieving batch result failed.");
-                } else {
-                    test:assertFail(msg = batchResultArr.toString());
-                }
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-            }
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(queryJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-        } else {
-            test:assertFail(msg = closedJob.message());
-        }
-    } else {
-        test:assertFail(msg = queryJob.message());
     }
+
+    //get job info
+    error|JobInfo jobInfo = baseClient->getJobInfo(queryJob);
+    if (jobInfo is JobInfo) {
+        test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    } else {
+        test:assertFail(msg = jobInfo.message());
+    }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(queryJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(queryJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
+            }
+        }
+    }
+
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(queryJob, batchId);
+        if (batchRequest is string) {
+            test:assertTrue(batchRequest.startsWith("SELECT"), msg = "Retrieving batch request failed.");
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
+            break;
+        }
+    }
+
+    //get batch result
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(queryJob, batchId);
+        if (batchResult is json) {
+            json[]|error batchResultArr = <json[]>batchResult;
+            if (batchResultArr is json[]) {
+                test:assertTrue(batchResultArr.length() == 4, msg = "Retrieving batch result failed.");
+            } else {
+                test:assertFail(msg = batchResultArr.toString());
+            }
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+        }
+    }
+
+    //close job
+    JobInfo closedJob = check baseClient->closeJob(queryJob);
+    test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
 }

--- a/sfdc/modules/bulk/tests/bulk_json_update.bal
+++ b/sfdc/modules/bulk/tests/bulk_json_update.bal
@@ -22,7 +22,7 @@ import ballerina/lang.runtime;
     enable: true,
     dependsOn: [insertJson, upsertJson]
 }
-function updateJson() {
+function updateJson() returns error? {
     log:printInfo("baseClient -> updateJson");
     string batchId = "";
     string mornsId = getContactIdByName("Remus", "Lupin", "Professor Level 03");
@@ -48,124 +48,116 @@ function updateJson() {
     }];
 
     //create job
-    error|BulkJob updateJob = baseClient->createJob("update", "Contact", "JSON");
+    BulkJob updateJob = check baseClient->createJob("update", "Contact", "JSON");
 
-    if (updateJob is BulkJob) {
-        //add json content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using json.");
-                batchId = batch.id;
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
-            }
-        }
-
-        //get job info
-        error|JobInfo jobInfo = baseClient->getJobInfo(updateJob);
-        if (jobInfo is JobInfo) {
-            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    //add json content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using json.");
+            batchId = batch.id;
+            break;
         } else {
-            test:assertFail(msg = jobInfo.message());
-        }
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(updateJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
-
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(updateJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
-
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(updateJob, batchId);
-            if (batchRequest is json) {
-                json[]|error batchRequestArr = <json[]>batchRequest;
-                if (batchRequestArr is json[]) {
-                    test:assertTrue(batchRequestArr.length() == 2, msg = "Retrieving batch request failed.");
-                } else {
-                    test:assertFail(msg = batchRequestArr.toString());
-                }
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
-            } else {
-                test:assertFail(msg = "Invalid Batch Request!");
-                break;
-            }
-        }
-
-        //get batch result
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(updateJob, batchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-            }
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(updateJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-        } else {
-            test:assertFail(msg = closedJob.message());
-        }
-    } else {
-        test:assertFail(msg = updateJob.message());
     }
+
+    //get job info
+    error|JobInfo jobInfo = baseClient->getJobInfo(updateJob);
+    if (jobInfo is JobInfo) {
+        test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    } else {
+        test:assertFail(msg = jobInfo.message());
+    }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(updateJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(updateJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
+            }
+        }
+    }
+
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(updateJob, batchId);
+        if (batchRequest is json) {
+            json[]|error batchRequestArr = <json[]>batchRequest;
+            if (batchRequestArr is json[]) {
+                test:assertTrue(batchRequestArr.length() == 2, msg = "Retrieving batch request failed.");
+            } else {
+                test:assertFail(msg = batchRequestArr.toString());
+            }
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
+            break;
+        }
+    }
+
+    //get batch result
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(updateJob, batchId);
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            foreach Result res in batchResult {
+                test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
+            }
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+        }
+    }
+
+    //close job
+    JobInfo closedJob = check baseClient->closeJob(updateJob);
+    test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
 }

--- a/sfdc/modules/bulk/tests/bulk_xml_delete.bal
+++ b/sfdc/modules/bulk/tests/bulk_xml_delete.bal
@@ -19,126 +19,119 @@ import ballerina/test;
 import ballerina/lang.runtime;
 
 @test:AfterSuite {}
-function deleteXml() {
+function deleteXml() returns error? {
     log:printInfo("baseClient -> deleteXml");
     string batchId = "";
-    xml contacts = getXmlContactsToDelete(xmlQueryResult);
+    xml contacts = xml `<sObjects xmlns="http://www.force.com/2009/06/asyncapi/dataload">${xmlInsertResult}</sObjects>`;
+
     //create job
-    error|BulkJob deleteJob = baseClient->createJob("delete", "Contact", "XML");
+    BulkJob deleteJob = check baseClient->createJob("delete", "Contact", "XML");
 
-    if (deleteJob is BulkJob) {
-        //add xml content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(deleteJob, contacts);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts to delete using xml.");
-                batchId = batch.id;
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
-            }
-        }
-
-        //get job info
-        error|JobInfo jobInfo = baseClient->getJobInfo(deleteJob);
-        if (jobInfo is JobInfo) {
-            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    //add xml content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(deleteJob, contacts);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts to delete using xml.");
+            batchId = batch.id;
+            break;
         } else {
-            test:assertFail(msg = jobInfo.message());
-        }
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(deleteJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
-
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(deleteJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
-
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(deleteJob, batchId);
-            if (batchRequest is xml) {
-                test:assertTrue((batchRequest/<*>).length() == 4, msg = "Retrieving batch request failed.");
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
-            } else {
-                test:assertFail("Invalid batch request!");
-                break;
-            }
-        }
-
-        //get batch result
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(deleteJob, batchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-                break;
-            }
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(deleteJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-        } else {
-            test:assertFail(msg = closedJob.message());
-        }
-
-    } else {
-        test:assertFail(msg = deleteJob.message());
     }
+
+    //get job info
+    error|JobInfo jobInfo = baseClient->getJobInfo(deleteJob);
+    if (jobInfo is JobInfo) {
+        test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    } else {
+        test:assertFail(msg = jobInfo.message());
+    }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(deleteJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(deleteJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
+            }
+        }
+    }
+
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(deleteJob, batchId);
+        if (batchRequest is xml) {
+            test:assertTrue((batchRequest/<*>).length() == 4, msg = "Retrieving batch request failed.");
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail("Invalid batch request!");
+            break;
+        }
+    }
+
+    //get batch result
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(deleteJob, batchId);
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            foreach Result res in batchResult {
+                test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
+            }
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+            break;
+        }
+    }
+
+    //close job
+    JobInfo closedJob = check baseClient->closeJob(deleteJob);
+    test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
+
 }

--- a/sfdc/modules/bulk/tests/bulk_xml_query.bal
+++ b/sfdc/modules/bulk/tests/bulk_xml_query.bal
@@ -22,124 +22,120 @@ import ballerina/lang.runtime;
     enable: true,
     dependsOn: [updateXml, insertXmlFromFile]
 }
-function queryXml() {
+function queryXml() returns error? {
+    runtime:sleep(delayInSecs);
     log:printInfo("baseClient -> queryXml");
     string batchId = "";
     string queryStr = "SELECT Id, Name FROM Contact WHERE Title='Professor Level 01'";
     //create job
-    error|BulkJob queryJob = baseClient->createJob("query", "Contact", "XML");
+    BulkJob queryJob = check baseClient->createJob("query", "Contact", "XML");
 
-    if (queryJob is BulkJob) {
-        //add xml content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(queryJob, queryStr);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload batch.");
-                batchId = batch.id;
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
-            }
-        }
-
-        //get job info
-        error|JobInfo jobInfo = baseClient->getJobInfo(queryJob);
-        if (jobInfo is JobInfo) {
-            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    //add xml content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(queryJob, queryStr);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload batch.");
+            batchId = batch.id;
+            break;
         } else {
-            test:assertFail(msg = jobInfo.message());
-        }
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(queryJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
-
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(queryJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
-
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(queryJob, batchId);
-            if (batchRequest is string) {
-                test:assertTrue(batchRequest.startsWith("SELECT"), msg = "Retrieving batch request failed.");
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
-            } else {
-                test:assertFail(msg = "Invalid Batch Request!");
-                break;
-            }
-        }
-
-        //get batch result
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(queryJob, batchId);
-            if (batchResult is xml) {
-                test:assertTrue((batchResult/<*>).length() == 4, msg = "Retrieving batch result failed.");
-                xmlQueryResult = <@untainted>batchResult;
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-                break;
-            }
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(queryJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-        } else {
-            test:assertFail(msg = closedJob.message());
-        }
-
-    } else {
-        test:assertFail(msg = queryJob.message());
     }
+
+    //get job info
+    error|JobInfo jobInfo = baseClient->getJobInfo(queryJob);
+    if (jobInfo is JobInfo) {
+        test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    } else {
+        test:assertFail(msg = jobInfo.message());
+    }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(queryJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(queryJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
+            }
+        }
+    }
+
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(queryJob, batchId);
+        if (batchRequest is string) {
+            test:assertTrue(batchRequest.startsWith("SELECT"), msg = "Retrieving batch request failed.");
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail(msg = "Invalid Batch Request!");
+            break;
+        }
+    }
+
+    //get batch result
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(queryJob, batchId);
+        if (batchResult is xml) {
+            test:assertTrue((batchResult/<*>).length() == 4, msg = "Retrieving batch result failed.");
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+            break;
+        }
+    }
+
+    //close job
+    error|JobInfo closedJob = baseClient->closeJob(queryJob);
+    if (closedJob is JobInfo) {
+        test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
+    } else {
+        test:assertFail(msg = closedJob.message());
+    }
+
 }

--- a/sfdc/modules/bulk/tests/bulk_xml_update.bal
+++ b/sfdc/modules/bulk/tests/bulk_xml_update.bal
@@ -22,7 +22,7 @@ import ballerina/lang.runtime;
     enable: true,
     dependsOn: [insertXml, upsertXml]
 }
-function updateXml() {
+function updateXml() returns error? {
     log:printInfo("baseClient -> updateXml");
     string batchId = "";
     string flitchID = getContactIdByName("Argus", "Filch", "Professor Level 01");
@@ -50,121 +50,116 @@ function updateXml() {
         </sObject>
     </sObjects>`;
     //create job
-    error|BulkJob updateJob = baseClient->createJob("update", "Contact", "XML");
+    BulkJob updateJob = check baseClient->createJob("update", "Contact", "XML");
 
-    if (updateJob is BulkJob) {
-        //add xml content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using xml.");
-                batchId = batch.id;
-                break;
-            } else {                
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
-            }
-        }
-
-        //get job info
-        error|JobInfo jobInfo = baseClient->getJobInfo(updateJob);
-        if (jobInfo is JobInfo) {
-            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    //add xml content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using xml.");
+            batchId = batch.id;
+            break;
         } else {
-            test:assertFail(msg = jobInfo.message());
-        }
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(updateJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
+    }
 
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(updateJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
-
-        //get batch request
-        foreach var i in 1 ..< maxIterations {
-            var batchRequest = baseClient->getBatchRequest(updateJob, batchId);
-            if (batchRequest is xml) {
-                test:assertTrue((batchRequest/<*>).length() == 2, msg = "Retrieving batch request failed.");
-                break;
-            } else if (batchRequest is error) {
-                if i != 5 {
-                    log:printWarn("getBatchRequest Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchRequest Operation Failed! Giving up...");
-                    test:assertFail(msg = batchRequest.message());
-                }
-            } else {
-                test:assertFail("Invalid batch request!");
-                break;
-            }
-        }
-
-        //get batch result
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(updateJob, batchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-                break;
-            }
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(updateJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-        } else {
-            test:assertFail(msg = closedJob.message());
-        }
-
+    //get job info
+    error|JobInfo jobInfo = baseClient->getJobInfo(updateJob);
+    if (jobInfo is JobInfo) {
+        test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
     } else {
-        test:assertFail(msg = updateJob.message());
+        test:assertFail(msg = jobInfo.message());
+    }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(updateJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(updateJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
+            }
+        }
+    }
+
+    //get batch request
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchRequest = baseClient->getBatchRequest(updateJob, batchId);
+        if (batchRequest is xml) {
+            test:assertTrue((batchRequest/<*>).length() == 2, msg = "Retrieving batch request failed.");
+            break;
+        } else if (batchRequest is error) {
+            if i != 5 {
+                log:printWarn("getBatchRequest Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchRequest Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchRequest.message());
+            }
+        } else {
+            test:assertFail("Invalid batch request!");
+            break;
+        }
+    }
+
+    //get batch result
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(updateJob, batchId);
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            foreach Result res in batchResult {
+                test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
+            }
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+            break;
+        }
+    }
+
+    //close job
+    error|JobInfo closedJob = baseClient->closeJob(updateJob);
+    if (closedJob is JobInfo) {
+        test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
+    } else {
+        test:assertFail(msg = closedJob.message());
     }
 }

--- a/sfdc/modules/bulk/tests/bulk_xml_upsert.bal
+++ b/sfdc/modules/bulk/tests/bulk_xml_upsert.bal
@@ -22,7 +22,7 @@ import ballerina/lang.runtime;
     enable: true,
     dependsOn: [insertXml]
 }
-function upsertXml() {
+function upsertXml() returns error? {
     log:printInfo("baseClient -> upsertXml");
     string batchId = "";
     xml contacts = xml `<sObjects xmlns="http://www.force.com/2009/06/asyncapi/dataload">
@@ -46,110 +46,105 @@ function upsertXml() {
         </sObject>
     </sObjects>`;
     //create job
-    error|BulkJob upsertJob = baseClient->createJob("upsert", "Contact", "XML", "My_External_Id__c");
+    BulkJob upsertJob = check baseClient->createJob("upsert", "Contact", "XML", "My_External_Id__c");
 
-    if (upsertJob is BulkJob) {
-        //add xml content
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batch = baseClient->addBatch(upsertJob, contacts);
-            if (batch is BatchInfo) {
-                test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using xml.");
-                batchId = batch.id;
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("addBatch Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("addBatch Operation Failed! Giving up...");
-                    test:assertFail(msg = batch.message());
-                }
-            }
-        }
-
-        //get job info
-        error|JobInfo jobInfo = baseClient->getJobInfo(upsertJob);
-        if (jobInfo is JobInfo) {
-            test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
+    //add xml content
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batch = baseClient->addBatch(upsertJob, contacts);
+        if (batch is BatchInfo) {
+            test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using xml.");
+            batchId = batch.id;
+            break;
         } else {
-            test:assertFail(msg = jobInfo.message());
-        }
-
-        //get batch info
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo batchInfo = baseClient->getBatchInfo(upsertJob, batchId);
-            if (batchInfo is BatchInfo) {
-                test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
-                break;
+            if i != 5 {
+                log:printWarn("addBatch Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
             } else {
-                if i != 5 {
-                    log:printWarn("getBatchInfo Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchInfo Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfo.message());
-                }
+                log:printWarn("addBatch Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batch.message());
             }
         }
+    }
 
-        //get all batches
-        foreach var i in 1 ..< maxIterations {
-            error|BatchInfo[] batchInfoList = baseClient->getAllBatches(upsertJob);
-            if (batchInfoList is BatchInfo[]) {
-                test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
-                break;
-            } else {
-                if i != 5 {
-                    log:printWarn("getAllBatches Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getAllBatches Operation Failed! Giving up...");
-                    test:assertFail(msg = batchInfoList.message());
-                }
-            }
-        }
-
-        //get batch request
-        var batchRequest = baseClient->getBatchRequest(upsertJob, batchId);
-        if (batchRequest is xml) {
-            test:assertTrue((batchRequest/<*>).length() == 2, msg = "Retrieving batch request failed.");
-        } else if (batchRequest is error) {
-            test:assertFail(msg = batchRequest.message());
-        } else {
-            test:assertFail("Invalid batch request!");
-        }
-
-        //get batch result
-        foreach var i in 1 ..< maxIterations {
-            var batchResult = baseClient->getBatchResult(upsertJob, batchId);
-            if (batchResult is Result[]) {
-                test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
-                foreach Result res in batchResult {
-                    test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
-                }                
-                break;
-            } else if (batchResult is error) {
-                if i != 5 {
-                    log:printWarn("getBatchResult Operation Failed! Retrying...");
-                    runtime:sleep(delayInSecs);
-                } else {
-                    log:printWarn("getBatchResult Operation Failed! Giving up...");
-                    test:assertFail(msg = batchResult.message());
-                }
-            } else {
-                test:assertFail("Invalid Batch Result!");
-            }
-        }
-
-        //close job
-        error|JobInfo closedJob = baseClient->closeJob(upsertJob);
-        if (closedJob is JobInfo) {
-            test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
-        } else {
-            test:assertFail(msg = closedJob.message());
-        }
-
+    //get job info
+    error|JobInfo jobInfo = baseClient->getJobInfo(upsertJob);
+    if (jobInfo is JobInfo) {
+        test:assertTrue(jobInfo.id.length() > 0, msg = "Getting job info failed.");
     } else {
-        test:assertFail(msg = upsertJob.message());
+        test:assertFail(msg = jobInfo.message());
+    }
+
+    //get batch info
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo batchInfo = baseClient->getBatchInfo(upsertJob, batchId);
+        if (batchInfo is BatchInfo) {
+            test:assertTrue(batchInfo.id == batchId, msg = "Getting batch info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getBatchInfo Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchInfo Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfo.message());
+            }
+        }
+    }
+
+    //get all batches
+    foreach var i in 1 ..< maxIterations + 1 {
+        error|BatchInfo[] batchInfoList = baseClient->getAllBatches(upsertJob);
+        if (batchInfoList is BatchInfo[]) {
+            test:assertTrue(batchInfoList.length() == 1, msg = "Getting all batches info failed.");
+            break;
+        } else {
+            if i != 5 {
+                log:printWarn("getAllBatches Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getAllBatches Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchInfoList.message());
+            }
+        }
+    }
+
+    //get batch request
+    var batchRequest = baseClient->getBatchRequest(upsertJob, batchId);
+    if (batchRequest is xml) {
+        test:assertTrue((batchRequest/<*>).length() == 2, msg = "Retrieving batch request failed.");
+    } else if (batchRequest is error) {
+        test:assertFail(msg = batchRequest.message());
+    } else {
+        test:assertFail("Invalid batch request!");
+    }
+
+    //get batch result
+    foreach var i in 1 ..< maxIterations + 1 {
+        var batchResult = baseClient->getBatchResult(upsertJob, batchId);
+        if (batchResult is Result[]) {
+            test:assertTrue(batchResult.length() > 0, msg = "Retrieving batch result failed.");
+            foreach Result res in batchResult {
+                test:assertTrue(checkBatchResults(res), msg = res?.errors.toString());
+            }
+            break;
+        } else if (batchResult is error) {
+            if i != 5 {
+                log:printWarn("getBatchResult Operation Failed! Retrying...");
+                runtime:sleep(delayInSecs);
+            } else {
+                log:printWarn("getBatchResult Operation Failed! Giving up after 5 tries.");
+                test:assertFail(msg = batchResult.message());
+            }
+        } else {
+            test:assertFail("Invalid Batch Result!");
+        }
+    }
+
+    //close job
+    error|JobInfo closedJob = baseClient->closeJob(upsertJob);
+    if (closedJob is JobInfo) {
+        test:assertTrue(closedJob.state == "Closed", msg = "Closing job failed.");
+    } else {
+        test:assertFail(msg = closedJob.message());
     }
 }

--- a/sfdc/modules/bulk/tests/utils.bal
+++ b/sfdc/modules/bulk/tests/utils.bal
@@ -17,18 +17,13 @@
 import ballerina/io;
 import ballerina/log;
 import ballerina/test;
-import ballerina/lang.'xml as xmllib;
 import ballerina/regex;
 import ballerina/os;
 import ballerinax/sfdc;
 
-json[] jsonQueryResult = [];
-xml xmlQueryResult = xml `<test/>`;
-string csvQueryResult = "";
-
-
-// import ballerina/log;
-// import ballerina/test;
+json[] jsonInsertResult = [];
+xml xmlInsertResult = xml ``;
+string csvInputResult = "Id";
 
 // Create Salesforce client configuration by reading from environemnt.
 configurable string & readonly clientId = os:getEnv("CLIENT_ID");
@@ -94,44 +89,11 @@ function getContactIdByName(string firstName, string lastName, string title) ret
 isolated function getJsonContactsToDelete(json[] resultList) returns json[] {
     json[] contacts = [];
     foreach var item in resultList {
-        json|error itemId = item.Id;
+        json|error itemId = item.id;
         if (itemId is json) {
             string id = itemId.toString();
             contacts[contacts.length()] = {"Id": id};
         }
-    }
-    return contacts;
-}
-
-isolated function getXmlContactsToDelete(xml resultList) returns xml {
-    xmllib:Element contacts = <xmllib:Element>xml `<sObjects xmlns="http://www.force.com/2009/06/asyncapi/dataload"/>`;
-
-    xmlns "http://www.force.com/2009/06/asyncapi/dataload" as ns;
-
-    xmllib:Element ele = <xmllib:Element>resultList;
-    foreach var item in ele.getChildren().elements() {
-        string id = (item/<ns:Id>[0]/*).toString();
-        xml child = xml `<sObject><Id>${id}</Id></sObject>`;
-        contacts.setChildren(contacts.getChildren() + child);
-    }
-    return contacts;
-}
-
-isolated function getCsvContactsToDelete(string resultString) returns string {
-    string contacts = "Id";
-    string[] lineArray = regex:split(resultString, "\n");
-    int arrLength = lineArray.length();
-    int counter = 1;
-    while (counter < arrLength) {
-        string? line = lineArray[counter];
-        if (line is string) {
-            int? inof = line.indexOf(",");
-            if (inof is int) {
-                string id = line.substring(0, inof);
-                contacts = contacts.concat("\n", id);
-            }
-        }
-        counter = counter + 1;
     }
     return contacts;
 }


### PR DESCRIPTION
## Purpose
Fix intermittent test case failures.

## Goals
Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/36

## Approach
According to the test failure reports, identified there are two issues.
- Query operation test cases failures.
- Test aftersuite couldn't delete  records in case if there is an error.

So in the current approach, 
- A sleep time is added before calling query operations ,
- Picked the record IDs from created operation response instead of getting those from query operation response.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
