### PR TITLE
Improvements for HTTP error logs in Salesforce connector

### DIFF
--- a/sfdc/errors.bal
+++ b/sfdc/errors.bal
@@ -14,16 +14,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-# Salesforce connector error
-public type Error distinct error;
+# Salesforce connector error.
+public type Error error<ErrorDetails>;
 
-// Logs and prepares the `error` as an `sfdc:Error`.
-isolated function prepareError(string message, error? err = ()) returns Error {
-    if (err is error) {
-        return error Error(message, err);
-    }
-    return error Error(message);
-}
+# Additional details extracted from the Http error.
+#
+# + statusCode - Http status code of the error
+# + headers - Http headers in the error response
+# + body - Response body with extra information
+public type ErrorDetails record {
+    int? statusCode?;
+    map<string[]>? headers?;
+    anydata[]? body?;
+};
 
 // Error constants
 const string JSON_ACCESSING_ERROR_MSG = "Error occurred while accessing the JSON payload of the response.";

--- a/sfdc/modules/bulk/client.bal
+++ b/sfdc/modules/bulk/client.bal
@@ -342,24 +342,24 @@ public isolated client class Client {
             JSON => {
                 json resultResponse = check checkJsonPayloadAndSetErrors(response);
                 if (QUERY == bulkJob.operation) {
-                    return getJsonQueryResult(<@untainted>resultResponse, path, <@untainted>self.salesforceClient, 
-                        <@untainted> self.clientHandler);
+                    return getJsonQueryResult(resultResponse, path, self.salesforceClient, 
+                         self.clientHandler);
                 }
                 return createBatchResultRecordFromJson(resultResponse);
             }
             XML => {
                 xml resultResponse = check checkXmlPayloadAndSetErrors(response);
                 if (QUERY == bulkJob.operation) {
-                    return getXmlQueryResult(<@untainted>resultResponse, path, <@untainted>self.salesforceClient, 
-                        <@untainted> self.clientHandler);
+                    return getXmlQueryResult(resultResponse, path, self.salesforceClient, 
+                         self.clientHandler);
                 }
                 return createBatchResultRecordFromXml(resultResponse);
             }
             CSV => {
                 if (QUERY == bulkJob.operation) {
                     xml resultResponse = check checkXmlPayloadAndSetErrors(response);
-                    return getCsvQueryResult(<@untainted>resultResponse, path, <@untainted>self.salesforceClient, 
-                        <@untainted> self.clientHandler);
+                    return getCsvQueryResult(resultResponse, path, self.salesforceClient, 
+                         self.clientHandler);
                 }
                 string resultResponse = check checkTextPayloadAndSetErrors(response);
                 return createBatchResultRecordFromCsv(resultResponse);

--- a/sfdc/modules/bulk/tests/bulk_csv_insert.bal
+++ b/sfdc/modules/bulk/tests/bulk_csv_insert.bal
@@ -186,7 +186,7 @@ function insertCsvFromFile() {
         io:ReadableByteChannel|io:Error rbc = io:openReadableFile(csvContactsFilePath);
         if (rbc is io:ReadableByteChannel) {
             foreach int currentRetry in 1 ..< maxIterations + 1 {
-                error|BatchInfo batchUsingCsvFile = baseClient->addBatch(insertJob, <@untainted>rbc);
+                error|BatchInfo batchUsingCsvFile = baseClient->addBatch(insertJob, rbc);
                 if (batchUsingCsvFile is BatchInfo) {
                     test:assertTrue(batchUsingCsvFile.id.length() > 0, 
                     msg = "Could not upload the contacts using CSV file.");

--- a/sfdc/modules/bulk/tests/bulk_csv_update.bal
+++ b/sfdc/modules/bulk/tests/bulk_csv_update.bal
@@ -36,7 +36,7 @@ function updateCsv() returns error? {
 
     //add csv content
     foreach int currentRetry in 1 ..< maxIterations + 1 {
-        error|BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        error|BatchInfo batch = baseClient->addBatch(updateJob, contacts);
         if (batch is BatchInfo) {
             test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using CSV.");
             batchId = batch.id;

--- a/sfdc/modules/bulk/tests/bulk_json_insert.bal
+++ b/sfdc/modules/bulk/tests/bulk_json_insert.bal
@@ -196,7 +196,7 @@ function insertJsonFromFile() returns error? {
     io:ReadableByteChannel|io:Error rbc = io:openReadableFile(jsonContactsFilePath);
     if (rbc is io:ReadableByteChannel) {
         foreach int currentRetry in 1 ..< maxIterations + 1 {
-            error|BatchInfo batchUsingJsonFile = baseClient->addBatch(jsonInsertJob, <@untainted>rbc);
+            error|BatchInfo batchUsingJsonFile = baseClient->addBatch(jsonInsertJob, rbc);
             if (batchUsingJsonFile is BatchInfo) {
                 test:assertTrue(batchUsingJsonFile.id.length() > 0, 
                     msg = "Could not upload the contacts using json file.");

--- a/sfdc/modules/bulk/tests/bulk_json_update.bal
+++ b/sfdc/modules/bulk/tests/bulk_json_update.bal
@@ -52,7 +52,7 @@ function updateJson() returns error? {
 
     //add json content
     foreach int currentRetry in 1 ..< maxIterations + 1 {
-        error|BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        error|BatchInfo batch = baseClient->addBatch(updateJob, contacts);
         if (batch is BatchInfo) {
             test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using json.");
             batchId = batch.id;

--- a/sfdc/modules/bulk/tests/bulk_xml_insert.bal
+++ b/sfdc/modules/bulk/tests/bulk_xml_insert.bal
@@ -176,7 +176,7 @@ function insertXmlFromFile() returns error? {
     io:ReadableByteChannel|io:Error rbc = io:openReadableFile(xmlContactsFilePath);
     if (rbc is io:ReadableByteChannel) {
         foreach int currentRetry in 1 ..< maxIterations + 1 {
-            error|BatchInfo batchUsingXmlFile = baseClient->addBatch(xmlInsertJob, <@untainted>rbc);
+            error|BatchInfo batchUsingXmlFile = baseClient->addBatch(xmlInsertJob, rbc);
             if (batchUsingXmlFile is BatchInfo) {
                 test:assertTrue(batchUsingXmlFile.id.length() > 0, msg = "Could not upload the contacts using xml file.");
                 xmlBatchId = batchUsingXmlFile.id;

--- a/sfdc/modules/bulk/tests/bulk_xml_update.bal
+++ b/sfdc/modules/bulk/tests/bulk_xml_update.bal
@@ -54,7 +54,7 @@ function updateXml() returns error? {
 
     //add xml content
     foreach int currentRetry in 1 ..< maxIterations + 1 {
-        error|BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        error|BatchInfo batch = baseClient->addBatch(updateJob, contacts);
         if (batch is BatchInfo) {
             test:assertTrue(batch.id.length() > 0, msg = "Could not upload the contacts using xml.");
             batchId = batch.id;

--- a/sfdc/rest_client.bal
+++ b/sfdc/rest_client.bal
@@ -60,7 +60,7 @@ public isolated client class Client {
         if (httpClientResult is http:Client) {
             self.salesforceClient = httpClientResult;
         } else {
-            return prepareError(INVALID_CLIENT_CONFIG);
+            return error Error(INVALID_CLIENT_CONFIG);
         }
     }
 
@@ -69,8 +69,9 @@ public isolated client class Client {
     #
     # + return - `OrgMetadata` record if successful or else `sfdc:Error`
     @display {label: "Get Available Objects"}
-    isolated remote function describeAvailableObjects() returns @tainted @display {label: "Organization Metadata"} 
-    OrgMetadata|Error {
+    isolated remote function describeAvailableObjects() 
+                                                      returns @tainted @display {label: "Organization Metadata"} 
+                                                      OrgMetadata|Error {
         string path = prepareUrl([API_BASE_PATH, SOBJECTS]);
         json res = check self->getRecord(path);
         return toOrgMetadata(res);
@@ -81,8 +82,9 @@ public isolated client class Client {
     # + sobjectName - SObject name
     # + return - `SObjectBasicInfo` record if successful or else `sfdc:Error`
     @display {label: "Get SObject Basic Information"}
-    isolated remote function getSObjectBasicInfo(@display {label: "SObject Name"} string sobjectName) returns @tainted @display 
-    {label: "SObject Basic Information"} SObjectBasicInfo|Error {
+    isolated remote function getSObjectBasicInfo(@display {label: "SObject Name"} string sobjectName) 
+                                                 returns @tainted @display {label: "SObject Basic Information"} 
+                                                 SObjectBasicInfo|Error {
         string path = prepareUrl([API_BASE_PATH, SOBJECTS, sobjectName]);
         json res = check self->getRecord(path);
         return toSObjectBasicInfo(res);
@@ -94,8 +96,8 @@ public isolated client class Client {
     # + sObjectName - SObject name value
     # + return - `SObjectMetaData` record if successful or else `sfdc:Error`
     @display {label: "Get SObject Description"}
-    isolated remote function describeSObject(@display {label: "SObject Name"} string sObjectName) returns @tainted @display 
-    {label: "SObject Metadata"} SObjectMetaData|Error {
+    isolated remote function describeSObject(@display {label: "SObject Name"} string sObjectName) 
+                                            returns @tainted @display {label: "SObject Metadata"} SObjectMetaData|Error {
         string path = prepareUrl([API_BASE_PATH, SOBJECTS, sObjectName, DESCRIBE]);
         json res = check self->getRecord(path);
         return toSObjectMetaData(res);
@@ -105,78 +107,12 @@ public isolated client class Client {
     #
     # + return - `SObjectBasicInfo` record if successful or else `sfdc:Error`
     @display {label: "Get SObject Platform Action"}
-    isolated remote function sObjectPlatformAction() returns @tainted @display {label: "SObject Basic Information"} 
-    SObjectBasicInfo|Error {
+    isolated remote function sObjectPlatformAction() 
+                                                  returns @tainted @display {label: "SObject Basic Information"} 
+                                                  SObjectBasicInfo|Error {
         string path = prepareUrl([API_BASE_PATH, SOBJECTS, PLATFORM_ACTION]);
         json res = check self->getRecord(path);
         return toSObjectBasicInfo(res);
-    }
-
-    //Basic CRUD
-    # Accesses records based on the specified object ID, can be used with external objects.
-    #
-    # + path - Resource path
-    # + return - JSON result if successful else or else `sfdc:Error`
-    @display {label: "Get Record"}
-    isolated remote function getRecord(@display {label: "Resource Path"} string path) returns @tainted @display 
-    {label: "Result"} json|Error {
-        http:Response|error response = self.salesforceClient->get(path);
-        return checkAndSetErrors(response);
-    }
-
-    # Creates records based on relevant object type sent with json record.
-    #
-    # + sObjectName - SObject name value
-    # + recordPayload - JSON record to be inserted
-    # + return - Created entity ID if successful or else `sfdc:Error`
-    @display {label: "Create Record"}
-    isolated remote function createRecord(@display {label: "SObject Name"} string sObjectName, @display 
-                                          {label: "Record Payload"} json recordPayload) returns @tainted @display 
-    {label: "Created Entity ID"} string|Error {
-        http:Request req = new;
-        string path = prepareUrl([API_BASE_PATH, SOBJECTS, sObjectName]);
-        req.setJsonPayload(recordPayload);
-
-        http:Response|error response = self.salesforceClient->post(path, req);
-        json result = check checkAndSetErrors(response);
-        json|error resultId = result.id;
-        if (resultId is json) {
-            return resultId.toString();
-        } else {
-            return error Error(resultId.message());
-        }
-    }
-
-    # Updates records based on relevant object ID.
-    #
-    # + sObjectName - SObject name value
-    # + id - SObject ID
-    # + recordPayload - JSON record to be updated
-    # + return - true if successful else false or else `sfdc:Error`
-    @display {label: "Update Record"}
-    isolated remote function updateRecord(@display {label: "SObject Name"} string sObjectName, @display 
-                                          {label: "SObject ID"} string id, 
-                                          @display {label: "Record Payload"} json recordPayload) returns @tainted @display 
-    {label: "Result"} Error? {
-        http:Request req = new;
-        string path = prepareUrl([API_BASE_PATH, SOBJECTS, sObjectName, id]);
-        req.setJsonPayload(recordPayload);
-        http:Response|error response = self.salesforceClient->patch(path, req);
-        _ = check checkAndSetErrors(response, false);
-    }
-
-    # Delete existing records based on relevant object ID.
-    #
-    # + sObjectName - SObject name value
-    # + id - SObject ID
-    # + return - true if successful else false or else `sfdc:Error`
-    @display {label: "Delete Record"}
-    isolated remote function deleteRecord(@display {label: "SObject Name"} string sObjectName, @display 
-                                          {label: "SObject ID"} string id) returns @tainted @display {label: "Result"} 
-    Error? {
-        string path = prepareUrl([API_BASE_PATH, SOBJECTS, sObjectName, id]);
-        http:Response|error response = self.salesforceClient->delete(path);
-        _ = check checkAndSetErrors(response, false);
     }
 
     # Gets an object record by ID.
@@ -186,9 +122,10 @@ public isolated client class Client {
     # + fields - Fields to retrieve 
     # + return - JSON result if successful or else `sfdc:Error`
     @display {label: "Get Record by ID"}
-    isolated remote function getRecordById(@display {label: "SObject Name"} string sobject, @display 
-                                           {label: "SObject ID"} string id, @display {label: "Fields to Retrieve"}
-                                           string... fields) returns @tainted @display {label: "Result"} json|Error {
+    isolated remote function getRecordById(@display {label: "SObject Name"} string sobject, 
+                                           @display {label: "SObject ID"} string id, 
+                                           @display {label: "Fields to Retrieve"} string... fields) 
+                                           returns @tainted @display {label: "Result"} json|Error {
         string path = prepareUrl([API_BASE_PATH, SOBJECTS, sobject, id]);
         if (fields.length() > 0) {
             path = path.concat(self.appendQueryParams(fields));
@@ -206,9 +143,10 @@ public isolated client class Client {
     # + return - JSON result if successful or else `sfdc:Error`
     @display {label: "Get Record by External ID"}
     isolated remote function getRecordByExtId(@display {label: "SObject Name"} string sobject, @display 
-                                              {label: "External ID Field Name"} string extIdField, @display 
-                                              {label: "External ID"} string extId, @display {label: "Fields to Retrieve"}
-                                              string... fields) returns @tainted @display {label: "Result"} json|Error {
+                                              {label: "External ID Field Name"} string extIdField, 
+                                              @display {label: "External ID"} string extId, 
+                                              @display {label: "Fields to Retrieve"} string... fields) 
+                                              returns @tainted @display {label: "Result"} json|Error {
         string path = prepareUrl([API_BASE_PATH, SOBJECTS, sobject, extIdField, extId]);
         if (fields.length() > 0) {
             path = path.concat(self.appendQueryParams(fields));
@@ -224,9 +162,9 @@ public isolated client class Client {
     # + fields - Fields to retireve
     # + return - JSON response if successful or else an sfdc:Error
     @display {label: "Get Account by ID"}
-    isolated remote function getAccountById(@display {label: "Account ID"} string accountId, @display 
-                                            {label: "Fields to Retrieve"}
-                                            string... fields) returns @tainted @display {label: "Result"} json|Error {
+    isolated remote function getAccountById(@display {label: "Account ID"} string accountId, 
+                                            @display {label: "Fields to Retrieve"} string... fields) 
+                                            returns @tainted @display {label: "Result"} json|Error {
         json res = check self->getRecordById(ACCOUNT, accountId, ...fields);
         return res;
     }
@@ -236,8 +174,8 @@ public isolated client class Client {
     # + accountRecord - Account JSON record to be inserted
     # + return - Account ID if successful or else an sfdc:Error
     @display {label: "Create Account"}
-    isolated remote function createAccount(@display {label: "Account Record"} json accountRecord) returns @tainted @display 
-    {label: "Account ID"} string|Error {
+    isolated remote function createAccount(@display {label: "Account Record"} json accountRecord) 
+                                           returns @tainted @display {label: "Account ID"} string|Error {
         return self->createRecord(ACCOUNT, accountRecord);
     }
 
@@ -246,8 +184,8 @@ public isolated client class Client {
     # + accountId - Account ID
     # + return - `true` if successful `false` otherwise, or an sfdc:Error in case of an error
     @display {label: "Delete Account"}
-    isolated remote function deleteAccount(@display {label: "Account ID"} string accountId) returns @tainted @display 
-    {label: "Result"} Error? {
+    isolated remote function deleteAccount(@display {label: "Account ID"} string accountId) 
+                                           returns @tainted @display {label: "Result"} Error? {
         return self->deleteRecord(ACCOUNT, accountId);
     }
 
@@ -257,9 +195,9 @@ public isolated client class Client {
     # + accountRecord - Account record JSON payload
     # + return - `true` if successful, `false` otherwise or an sfdc:Error in case of an error
     @display {label: "Update Account"}
-    isolated remote function updateAccount(@display {label: "Account ID"} string accountId, @display 
-                                           {label: "Account Record"} json accountRecord) returns @tainted @display 
-    {label: "Result"} Error? {
+    isolated remote function updateAccount(@display {label: "Account ID"} string accountId, 
+                                           @display {label: "Account Record"} json accountRecord) 
+                                           returns @tainted @display {label: "Result"} Error? {
         return self->updateRecord(ACCOUNT, accountId, accountRecord);
     }
 
@@ -270,9 +208,9 @@ public isolated client class Client {
     # + fields - Fields to retireve
     # + return - JSON response if successful or else an sfdc:Error
     @display {label: "Get Lead by ID"}
-    isolated remote function getLeadById(@display {label: "Lead ID"} string leadId, @display 
-                                         {label: "Fields to Retrieve"}
-                                         string... fields) returns @tainted @display {label: "Result"} json|Error {
+    isolated remote function getLeadById(@display {label: "Lead ID"} string leadId, 
+                                         @display {label: "Fields to Retrieve"} string... fields) 
+                                         returns @tainted @display {label: "Result"} json|Error {
         json res = check self->getRecordById(LEAD, leadId, ...fields);
         return res;
     }
@@ -282,8 +220,8 @@ public isolated client class Client {
     # + leadRecord - Lead JSON record to be inserted
     # + return - Lead ID if successful or else an sfdc:Error
     @display {label: "Create Lead"}
-    isolated remote function createLead(@display {label: "Lead Record"} json leadRecord) returns @tainted @display 
-    {label: "Lead ID"} string|Error {
+    isolated remote function createLead(@display {label: "Lead Record"} json leadRecord) 
+                                        returns @tainted @display {label: "Lead ID"} string|Error {
         return self->createRecord(LEAD, leadRecord);
     }
 
@@ -292,8 +230,8 @@ public isolated client class Client {
     # + leadId - Lead ID
     # + return - `true`  if successful, `false` otherwise or an sfdc:Error incase of an error
     @display {label: "Delete Lead"}
-    isolated remote function deleteLead(@display {label: "Lead ID"} string leadId) returns @tainted @display 
-    {label: "Result"} Error? {
+    isolated remote function deleteLead(@display {label: "Lead ID"} string leadId) 
+                                        returns @tainted @display {label: "Result"} Error? {
         return self->deleteRecord(LEAD, leadId);
     }
 
@@ -304,8 +242,8 @@ public isolated client class Client {
     # + return - `true` if successful, `false` otherwise or an sfdc:Error in case of an error
     @display {label: "Update Lead"}
     isolated remote function updateLead(@display {label: "Lead ID"} string leadId, 
-                                        @display {label: "Lead Record"} json leadRecord) returns @tainted @display 
-    {label: "Result"} Error? {
+                                        @display {label: "Lead Record"} json leadRecord) 
+                                        returns @tainted @display {label: "Result"} Error? {
         return self->updateRecord(LEAD, leadId, leadRecord);
     }
 
@@ -316,8 +254,8 @@ public isolated client class Client {
     # + fields - Fields to retireve
     # + return - JSON result if successful or else an sfdc:Error
     @display {label: "Get Contact by ID"}
-    isolated remote function getContactById(@display {label: "Contact ID"} string contactId, @display 
-                                            {label: "Fields to Retrieve"}
+    isolated remote function getContactById(@display {label: "Contact ID"} string contactId, 
+                                            @display {label: "Fields to Retrieve"}
                                             string... fields) returns @tainted @display {label: "Result"} json|Error {
         json res = check self->getRecordById(CONTACT, contactId, ...fields);
         return res;
@@ -328,8 +266,8 @@ public isolated client class Client {
     # + contactRecord - JSON contact record
     # + return - Contact ID if successful or else an sfdc:Error
     @display {label: "Create Contact"}
-    isolated remote function createContact(@display {label: "Contact Record"} json contactRecord) returns @tainted @display 
-    {label: "Contact ID"} string|Error {
+    isolated remote function createContact(@display {label: "Contact Record"} json contactRecord) 
+                                           returns @tainted @display {label: "Contact ID"} string|Error {
         return self->createRecord(CONTACT, contactRecord);
     }
 
@@ -338,8 +276,8 @@ public isolated client class Client {
     # + contactId - Contact ID
     # + return - `true` if successful, `false` otherwise or an sfdc:Error in case of an error
     @display {label: "Delete Contact"}
-    isolated remote function deleteContact(@display {label: "Contact ID"} string contactId) returns @tainted @display 
-    {label: "Result"} Error? {
+    isolated remote function deleteContact(@display {label: "Contact ID"} string contactId) 
+                                           returns @tainted @display {label: "Result"} Error? {
         return self->deleteRecord(CONTACT, contactId);
     }
 
@@ -349,9 +287,9 @@ public isolated client class Client {
     # + contactRecord - JSON contact record
     # + return - `true` if successful, `false` otherwise or an sfdc:Error in case of an error
     @display {label: "Update Contact"}
-    isolated remote function updateContact(@display {label: "Contact ID"} string contactId, @display 
-                                           {label: "Contact Record"} json contactRecord) returns @tainted @display 
-    {label: "Result"} Error? {
+    isolated remote function updateContact(@display {label: "Contact ID"} string contactId, 
+                                           @display {label: "Contact Record"} json contactRecord) 
+                                           returns @tainted @display {label: "Result"} Error? {
         return self->updateRecord(CONTACT, contactId, contactRecord);
     }
 
@@ -362,9 +300,9 @@ public isolated client class Client {
     # + fields - Fields to retireve
     # + return - JSON response if successful or else an sfdc:Error
     @display {label: "Get Opportunity by ID"}
-    isolated remote function getOpportunityById(@display {label: "Opportunity ID"} string opportunityId, @display 
-                                                {label: "Fields to Retrieve"}
-                                                string... fields) returns @tainted @display {label: "Result"} json|Error {
+    isolated remote function getOpportunityById(@display {label: "Opportunity ID"} string opportunityId, 
+                                                @display {label: "Fields to Retrieve"} string... fields) 
+                                                returns @tainted @display {label: "Result"} json|Error {
         json res = check self->getRecordById(OPPORTUNITY, opportunityId, ...fields);
         return res;
     }
@@ -374,8 +312,8 @@ public isolated client class Client {
     # + opportunityRecord - JSON opportunity record
     # + return - Opportunity ID if successful or else an sfdc:Error
     @display {label: "Create Opportunity"}
-    isolated remote function createOpportunity(@display {label: "Opportunity Record"} json opportunityRecord) returns @tainted @display 
-    {label: "Opportunity ID"} string|Error {
+    isolated remote function createOpportunity(@display {label: "Opportunity Record"} json opportunityRecord) 
+                                               returns @tainted @display {label: "Opportunity ID"} string|Error {
         return self->createRecord(OPPORTUNITY, opportunityRecord);
     }
 
@@ -384,8 +322,8 @@ public isolated client class Client {
     # + opportunityId - Opportunity ID
     # + return - `true` if successful, `false` otherwise or an sfdc:Error in case of an error
     @display {label: "Delete Opportunity"}
-    isolated remote function deleteOpportunity(@display {label: "Opportunity ID"} string opportunityId) returns @tainted @display 
-    {label: "Result"} Error? {
+    isolated remote function deleteOpportunity(@display {label: "Opportunity ID"} string opportunityId) 
+                                               returns @tainted @display {label: "Result"} Error? {
         return self->deleteRecord(OPPORTUNITY, opportunityId);
     }
 
@@ -395,9 +333,9 @@ public isolated client class Client {
     # + opportunityRecord - Opportunity JSON payload
     # + return - `true` if successful, `false` otherwise or an sfdc:Error in case of an error
     @display {label: "Update Opportunity"}
-    isolated remote function updateOpportunity(@display {label: "Opportunity ID"} string opportunityId, @display 
-                                               {label: "Opportunity Record"} json opportunityRecord) returns @tainted @display 
-    {label: "Result"} Error? {
+    isolated remote function updateOpportunity(@display {label: "Opportunity ID"} string opportunityId, 
+                                               @display {label: "Opportunity Record"} json opportunityRecord) 
+                                               returns @tainted @display {label: "Result"} Error? {
         return self->updateRecord(OPPORTUNITY, opportunityId, opportunityRecord);
     }
 
@@ -408,9 +346,9 @@ public isolated client class Client {
     # + fields - Fields to retireve
     # + return - JSON result if successful or else an sfdc:Error
     @display {label: "Get Product by ID"}
-    isolated remote function getProductById(@display {label: "Product ID"} string productId, @display 
-                                            {label: "Fields to Retrieve"}
-                                            string... fields) returns @tainted @display {label: "Result"} json|Error {
+    isolated remote function getProductById(@display {label: "Product ID"} string productId, 
+                                            @display {label: "Fields to Retrieve"} string... fields) 
+                                            returns @tainted @display {label: "Result"} json|Error {
         json res = check self->getRecordById(PRODUCT, productId, ...fields);
         return res;
     }
@@ -420,8 +358,8 @@ public isolated client class Client {
     # + productRecord - JSON product record
     # + return - Product ID if successful or else an sfdc:Error
     @display {label: "Create Product"}
-    isolated remote function createProduct(@display {label: "Product Record"} json productRecord) returns @tainted @display 
-    {label: "Product ID"} string|Error {
+    isolated remote function createProduct(@display {label: "Product Record"} json productRecord) 
+                                           returns @tainted @display {label: "Product ID"} string|Error {
         return self->createRecord(PRODUCT, productRecord);
     }
 
@@ -430,8 +368,8 @@ public isolated client class Client {
     # + productId - Product ID
     # + return - `true` if successful, `false` otherwise or an sfdc:Error in case of an error
     @display {label: "Delete Product"}
-    isolated remote function deleteProduct(@display {label: "Product ID"} string productId) returns @tainted @display 
-    {label: "Result"} Error? {
+    isolated remote function deleteProduct(@display {label: "Product ID"} string productId) 
+                                           returns @tainted @display {label: "Result"} Error? {
         return self->deleteRecord(PRODUCT, productId);
     }
 
@@ -441,9 +379,9 @@ public isolated client class Client {
     # + productRecord - JSON product record
     # + return - `true` if successful, `false` otherwise or an sfdc:Error in case of an error
     @display {label: "Update Product"}
-    isolated remote function updateProduct(@display {label: "Product ID"} string productId, @display 
-                                           {label: "Product Record"} json productRecord) returns @tainted @display 
-    {label: "Result"} Error? {
+    isolated remote function updateProduct(@display {label: "Product ID"} string productId, 
+                                           @display {label: "Product Record"} json productRecord) 
+                                           returns @tainted @display {label: "Result"} Error? {
         return self->updateRecord(PRODUCT, productId, productRecord);
     }
 
@@ -462,8 +400,8 @@ public isolated client class Client {
     # + receivedQuery - Sent SOQL query
     # + return - `SoqlResult` record if successful. Else, the occurred `Error`.
     @display {label: "Get Query Result"}
-    isolated remote function getQueryResult(@display {label: "SOQL Query"} string receivedQuery) returns @tainted @display 
-    {label: "SOQL Result"} SoqlResult|Error {
+    isolated remote function getQueryResult(@display {label: "SOQL Query"} string receivedQuery) 
+                                            returns @tainted @display {label: "SOQL Result"} SoqlResult|Error {
         string path = prepareQueryUrl([API_BASE_PATH, QUERY], [Q], [receivedQuery]);
         json res = check self->getRecord(path);
         return toSoqlResult(res);
@@ -474,8 +412,8 @@ public isolated client class Client {
     # + nextRecordsUrl - URL to get the next query results
     # + return - `SoqlResult` record if successful. Else, the occurred `Error`.
     @display {label: "Get Next Query Result"}
-    isolated remote function getNextQueryResult(@display {label: "Next Records URL"} string nextRecordsUrl) returns @tainted @display 
-    {label: "SOQL Result"} SoqlResult|Error {
+    isolated remote function getNextQueryResult(@display {label: "Next Records URL"} string nextRecordsUrl) 
+                                                returns @tainted @display {label: "SOQL Result"} SoqlResult|Error {
         json res = check self->getRecord(nextRecordsUrl);
         return toSoqlResult(res);
     }
@@ -486,8 +424,8 @@ public isolated client class Client {
     # + searchString - Sent SOSL search query
     # + return - `SoslResult` record if successful. Else, the occurred `Error`.
     @display {label: "SOSL Search"}
-    isolated remote function searchSOSLString(@display {label: "SOSL Search Query"} string searchString) returns @tainted @display 
-    {label: "SOSL Result"} SoslResult|Error {
+    isolated remote function searchSOSLString(@display {label: "SOSL Search Query"} string searchString) 
+                                              returns @tainted @display {label: "SOSL Result"} SoslResult|Error {
         string path = prepareQueryUrl([API_BASE_PATH, SEARCH], [Q], [searchString]);
         json res = check self->getRecord(path);
         return toSoslResult(res);
@@ -508,8 +446,8 @@ public isolated client class Client {
     # + apiVersion - API version (v37)
     # + return - `Resources` as map of strings if successful. Else, the occurred `Error`.
     @display {label: "Get Resources by API Version"}
-    isolated remote function getResourcesByApiVersion(@display {label: "API Version"} string apiVersion) returns @tainted @display 
-    {label: "Resources"} map<string>|Error {
+    isolated remote function getResourcesByApiVersion(@display {label: "API Version"} string apiVersion) 
+                                                      returns @tainted @display {label: "Resources"} map<string>|Error {
         string path = prepareUrl([BASE_PATH, apiVersion]);
         json res = check self->getRecord(path);
         return toMapOfStrings(res);
@@ -519,11 +457,89 @@ public isolated client class Client {
     #
     # + return - `OrganizationLimits` as map of `Limit` if successful. Else, the occurred `Error`.
     @display {label: "Get Organization Limits"}
-    isolated remote function getOrganizationLimits() returns @tainted @display {label: "Organization Limits"} map<Limit>|
-    Error {
+    isolated remote function getOrganizationLimits() 
+                                                   returns @tainted @display {label: "Organization Limits"} 
+                                                   map<Limit>|Error {
         string path = prepareUrl([API_BASE_PATH, LIMITS]);
         json res = check self->getRecord(path);
         return toMapOfLimits(res);
+    }
+
+    //Basic CRUD
+    # Accesses records based on the specified object ID, can be used with external objects.
+    #
+    # + path - Resource path
+    # + return - JSON result if successful else or else `sfdc:Error`
+    @display {label: "Get Record"}
+    isolated remote function getRecord(@display {label: "Resource Path"} string path) 
+                                       returns @tainted @display {label: "Result"} json|Error {
+        json|error response = self.salesforceClient->get(path);
+        if (response is json) {
+            return response;
+        } else {
+            return checkAndSetErrorDetail(response);
+        }
+    }
+
+    # Creates records based on relevant object type sent with json record.
+    #
+    # + sObjectName - SObject name value
+    # + recordPayload - JSON record to be inserted
+    # + return - Created entity ID if successful or else `sfdc:Error`
+    @display {label: "Create Record"}
+    isolated remote function createRecord(@display {label: "SObject Name"} string sObjectName, 
+                                          @display {label: "Record Payload"} json recordPayload) 
+                                          returns @tainted @display {label: "Created Entity ID"} string|Error {
+        http:Request req = new;
+        string path = prepareUrl([API_BASE_PATH, SOBJECTS, sObjectName]);
+        req.setJsonPayload(recordPayload);
+        json|error response = self.salesforceClient->post(path, req);
+        if (response is json) {
+            json|error resultId = response.id;
+            if (resultId is json) {
+                return resultId.toString();
+            } else {
+                return error Error(resultId.message());
+            }
+        } else {
+            return checkAndSetErrorDetail(response);
+        }
+    }
+
+    # Delete existing records based on relevant object ID.
+    #
+    # + sObjectName - SObject name value
+    # + id - SObject ID
+    # + return - true if successful else false or else `sfdc:Error`
+    @display {label: "Delete Record"}
+    isolated remote function deleteRecord(@display {label: "SObject Name"} string sObjectName, 
+                                          @display {label: "SObject ID"} string id) 
+                                          returns @tainted @display {label: "Result"} Error? {
+        string path = prepareUrl([API_BASE_PATH, SOBJECTS, sObjectName, id]);
+        http:Response|error response = self.salesforceClient->delete(path);
+        if (response is error) {
+            return checkAndSetErrorDetail(response);
+        }
+    }
+
+    # Updates records based on relevant object ID.
+    #
+    # + sObjectName - SObject name value
+    # + id - SObject ID
+    # + recordPayload - JSON record to be updated
+    # + return - true if successful else false or else `sfdc:Error`
+    @display {label: "Update Record"}
+    isolated remote function updateRecord(@display {label: "SObject Name"} string sObjectName, 
+                                          @display {label: "SObject ID"} string id, 
+                                          @display {label: "Record Payload"} json recordPayload) 
+                                          returns @tainted @display {label: "Result"} Error? {
+        http:Request req = new;
+        string path = prepareUrl([API_BASE_PATH, SOBJECTS, sObjectName, id]);
+        req.setJsonPayload(recordPayload);
+        http:Response|error response = self.salesforceClient->patch(path, req);
+        if (response is error) {
+            return checkAndSetErrorDetail(response);
+        }
     }
 }
 

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_file_insert_csv.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_file_insert_csv.bal
@@ -44,7 +44,7 @@ public function main(){
     if (insertJob is sfdc:BulkJob){
         io:ReadableByteChannel|io:Error rbc = io:openReadableFile(csvContactsFilePath);
         if (rbc is io:ReadableByteChannel) {
-            error|sfdc:BatchInfo batch = baseClient->addBatch(insertJob, <@untainted>rbc);
+            error|sfdc:BatchInfo batch = baseClient->addBatch(insertJob, rbc);
             if (batch is sfdc:BatchInfo) {
                 string message = batch.id.length() > 0 ? "Batch Added Successfully" :"Failed to add the Batch";
                 batchId = batch.id;

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_update_csv.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_update_csv.bal
@@ -47,7 +47,7 @@ public function main(){
     sfdc:BulkJob|error updateJob = baseClient->createJob("update", "Contact", "CSV");
 
     if (updateJob is sfdc:BulkJob){
-        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, contacts);
         if (batch is sfdc:BatchInfo) {
            string message = batch.id.length() > 0 ? "Batch Updated Successfully" :"Failed to Update the Batch";
            batchId = batch.id;

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_upsert_csv.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-csv/bulk_upsert_csv.bal
@@ -47,7 +47,7 @@ public function main(){
     sfdc:BulkJob|error updateJob = baseClient->createJob("upsert", "Contact", "CSV","My_External_Id__c");
 
     if (updateJob is sfdc:BulkJob){
-        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, contacts);
         if (batch is sfdc:BatchInfo) {
             batchId = batch.id;
             string message = batch.id.length() > 0 ? "Batch added to upsert Successfully" :"Failed to add the batch";

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_file_insert_json.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_file_insert_json.bal
@@ -42,7 +42,7 @@ public function main(){
     if (insertJob is sfdc:BulkJob){
         io:ReadableByteChannel|io:Error rbc = io:openReadableFile(jsonContactsFilePath);
         if (rbc is io:ReadableByteChannel){
-            error|sfdc:BatchInfo batch = baseClient->addBatch(insertJob, <@untainted>rbc);
+            error|sfdc:BatchInfo batch = baseClient->addBatch(insertJob, rbc);
             if (batch is sfdc:BatchInfo) {
                 string message = batch.id.length() > 0 ? "Batch Added Successfully" :"Failed to add the Batch";
                 batchId = batch.id;

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_query_json.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_query_json.bal
@@ -86,7 +86,7 @@ public function main(){
         if (batchResult is json) {
             json[]|error batchResultArr = <json[]>batchResult;
             if (batchResultArr is json[]) {
-                jsonQueryResult = <@untainted>batchResultArr;
+                jsonQueryResult = batchResultArr;
                 //io:println("count : " + batchResultArr.length().toString());
                 log:printInfo("Number of Records Received :" + batchResultArr.length().toString());
             } else {

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_update_json.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_update_json.bal
@@ -65,7 +65,7 @@ public function main(){
     sfdc:BulkJob|error updateJob = baseClient->createJob("update", "Contact", "JSON");
 
     if (updateJob is sfdc:BulkJob){
-        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, contacts);
         if (batch is sfdc:BatchInfo) {
            string message = batch.id.length() > 0 ? "Batch Updated Successfully" :"Failed to Update the Batch";
            batchId = batch.id;

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_upsert_json.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-json/bulk_upsert_json.bal
@@ -67,7 +67,7 @@ public function main(){
     sfdc:BulkJob|error updateJob = baseClient->createJob("upsert", "Contact", "JSON", "My_External_Id__c");
 
     if (updateJob is sfdc:BulkJob){
-        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, contacts);
         if (batch is sfdc:BatchInfo) {
             batchId = batch.id;
             string message = batch.id.length() > 0 ? "Batch added to upsert Successfully" :"Failed to add the batch";

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_file_insert_xml.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_file_insert_xml.bal
@@ -43,7 +43,7 @@ public function main(){
     if (insertJob is sfdc:BulkJob){
         io:ReadableByteChannel|io:Error rbc = io:openReadableFile(xmlContactsFilePath);
         if (rbc is io:ReadableByteChannel) {
-            error|sfdc:BatchInfo batch = baseClient->addBatch(insertJob, <@untainted>rbc);
+            error|sfdc:BatchInfo batch = baseClient->addBatch(insertJob, rbc);
             if (batch is sfdc:BatchInfo) {
             string message = batch.id.length() > 0 ? "Batch Added Successfully" :"Failed to add the Batch";
             batchId = batch.id;

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_update_xml.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_update_xml.bal
@@ -65,7 +65,7 @@ public function main(){
     sfdc:BulkJob|error updateJob = baseClient->createJob("update", "Contact", "XML");
 
     if (updateJob is sfdc:BulkJob){
-        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, contacts);
         if (batch is sfdc:BatchInfo) {
            string message = batch.id.length() > 0 ? "Batch Updated Successfully" :"Failed to Update the Batch";
            batchId = batch.id;

--- a/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_upsert_xml.bal
+++ b/sfdc/samples/bulk_api_usecases/bulk-operations-xml/bulk_upsert_xml.bal
@@ -67,7 +67,7 @@ public function main(){
     sfdc:BulkJob|error updateJob = baseClient->createJob("upsert", "Contact", "XML","My_External_Id__c");
 
     if (updateJob is sfdc:BulkJob){
-        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, <@untainted>contacts);
+        error|sfdc:BatchInfo batch = baseClient->addBatch(updateJob, contacts);
         if (batch is sfdc:BatchInfo) {
             batchId = batch.id;
             string message = batch.id.length() > 0 ? "Batch added to upsert Successfully" :"Failed to add the batch";

--- a/sfdc/samples/rest_api_usecases/account-related-usecases/account_get_by_id.bal
+++ b/sfdc/samples/rest_api_usecases/account-related-usecases/account_get_by_id.bal
@@ -39,7 +39,7 @@ public function main(){
 
     if (account is json) {
         json|error accountName = account.Name;
-        if(accountName is json){
+        if (accountName is json){
             log:printInfo("Account data retrieved successfully. Account Name : " + accountName.toString());
         }
     } else {

--- a/sfdc/samples/rest_api_usecases/find_record_by_query.bal
+++ b/sfdc/samples/rest_api_usecases/find_record_by_query.bal
@@ -43,7 +43,7 @@ public function main(){
             string|error nextRecordsUrl = res["nextRecordsUrl"].toString();
             while (nextRecordsUrl is string && nextRecordsUrl.trim() != "") {
                 log:printInfo("Found new query result set! nextRecordsUrl:" + nextRecordsUrl);
-                sfdc:SoqlResult|sfdc:Error nextRes = baseClient->getNextQueryResult(<@untainted>nextRecordsUrl);
+                sfdc:SoqlResult|sfdc:Error nextRes = baseClient->getNextQueryResult(nextRecordsUrl);
                 
                 if (nextRes is sfdc:SoqlResult) {
                     totalRecords = totalRecords + nextRes.records.length();

--- a/sfdc/tests/rest_api_test.bal
+++ b/sfdc/tests/rest_api_test.bal
@@ -54,7 +54,7 @@ function testCreateRecord() {
 
     if (stringResponse is string) {
         test:assertNotEquals(stringResponse, "", msg = "Found empty response!");
-        testRecordId = <@untainted>stringResponse;
+        testRecordId = stringResponse;
     } else {
         test:assertFail(msg = stringResponse.message());
     }
@@ -118,18 +118,13 @@ function testGetQueryResult() returns error? {
     string sampleQuery = "SELECT name FROM Account";
     SoqlResult res = check baseClient->getQueryResult(sampleQuery);
     assertSoqlResult(res);
-    string|error nextRecordsUrl = res["nextRecordsUrl"].toString();
+    string nextRecordsUrl = res["nextRecordsUrl"].toString();
 
-    while (nextRecordsUrl is string && nextRecordsUrl.trim() != EMPTY_STRING) {
+    while (nextRecordsUrl.trim() != EMPTY_STRING) {
         log:printInfo("Found new query result set! nextRecordsUrl:" + nextRecordsUrl);
-        SoqlResult|Error resp = baseClient->getNextQueryResult(<@untainted>nextRecordsUrl);
-
-        if (resp is SoqlResult) {
-            assertSoqlResult(resp);
-            res = resp;
-        } else {
-            test:assertFail(msg = resp.message());
-        }
+        SoqlResult resp = check baseClient->getNextQueryResult(nextRecordsUrl);
+        assertSoqlResult(resp);
+        res = resp;
     }
 }
 


### PR DESCRIPTION
# Description
This PR fixes the need for providing a proper  error logs in case of the occurrence of an HTTP error. In the legacy versions of the connector only the response body of the HTTP error was mapped to the error response so that if the HTTP error does not contain any response body there is no way to obtain the details about the error.

Fixes: https://github.com/ballerina-platform/ballerina-extended-library/issues/187

With the new changes, the end user can access all the details returned from the HTTP response as follows

```ballerina
import ballerina/io;
import ballerinax/sfdc;
import ballerina/os;

configurable string & readonly clientId = os:getEnv("CLIENT_ID");
configurable string & readonly clientSecret = os:getEnv("CLIENT_SECRET");
configurable string & readonly refreshToken = os:getEnv("REFRESH_TOKEN");
configurable string & readonly refreshUrl = os:getEnv("REFRESH_URL");
configurable string & readonly baseUrl = os:getEnv("EP_URL");

sfdc:ConnectionConfig sfConfig = {
    baseUrl: baseUrl,
    clientConfig: {
        clientId: clientId,
        clientSecret: clientSecret,
        refreshToken: refreshToken,
        refreshUrl: refreshUrl
    }
};
sfdc:Client baseClient = check new (sfConfig);

public function main() {
    json accountRecord = {
        Name: "John Keells Holdings",
        BillingCity: "Colombo 3",
        Hello: ""
    };
    
    string|sfdc:Error stringResponse = baseClient->createRecord("Account", accountRecord);

    if (stringResponse is string) {
        io:println(stringResponse);
    } else {
        io:println(stringResponse.message());
        io:println(stringResponse.cause());
        io:println(stringResponse.detail()?.statusCode);
        io:println(stringResponse.detail()?.headers);
        io:println(stringResponse.detail()?.body);
    }
}
```
This code will provide the details of the error as follows

```console
Failed to establish the communication with the upstream server or a data binding failure. Refer error.cause() for more details

error ClientRequestError ("Bad Request",statusCode=400,headers={"Cache-Control":["no-cache,must-revalidate,max-age=0,no-store,private"],"Content-Type":["application/json;charset=UTF-8"],"Date":["Thu, 09 Dec 2021 08:39:09 GMT"],"Set-Cookie":["CookieConsentPolicy=0:1; domain=wso267-dev-ed.my.salesforce.com; path=/; expires=Fri, 09-Dec-2022 08:39:09 GMT; Max-Age=31536000","LSKey-c$CookieConsentPolicy=0:1; domain=wso267-dev-ed.my.salesforce.com; path=/; expires=Fri, 09-Dec-2022 08:39:09 GMT; Max-Age=31536000","BrowserId=elfqIFjLEeyeKZe4dMl2JA; domain=.salesforce.com; path=/; expires=Fri, 09-Dec-2022 08:39:09 GMT; Max-Age=31536000"],"Sforce-Limit-Info":["api-usage=4477/15000"],"Strict-Transport-Security":["max-age=31536000; includeSubDomains"],"Transfer-Encoding":["chunked"],"X-Content-Type-Options":["nosniff"],"X-Robots-Tag":["none"],"X-XSS-Protection":["1; mode=block"]},body=[{"message":"No such column 'Hello' on sobject of type Account","errorCode":"INVALID_FIELD"}])

400

{"Cache-Control":["no-cache,must-revalidate,max-age=0,no-store,private"],"Content-Type":["application/json;charset=UTF-8"],"Date":["Thu, 09 Dec 2021 08:39:09 GMT"],"Set-Cookie":["CookieConsentPolicy=0:1; domain=wso267-dev-ed.my.salesforce.com; path=/; expires=Fri, 09-Dec-2022 08:39:09 GMT; Max-Age=31536000","LSKey-c$CookieConsentPolicy=0:1; domain=wso267-dev-ed.my.salesforce.com; path=/; expires=Fri, 09-Dec-2022 08:39:09 GMT; Max-Age=31536000","BrowserId=elfqIFjLEeyeKZe4dMl2JA; domain=.salesforce.com; path=/; expires=Fri, 09-Dec-2022 08:39:09 GMT; Max-Age=31536000"],"Sforce-Limit-Info":["api-usage=4477/15000"],"Strict-Transport-Security":["max-age=31536000; includeSubDomains"],"Transfer-Encoding":["chunked"],"X-Content-Type-Options":["nosniff"],"X-Robots-Tag":["none"],"X-XSS-Protection":["1; mode=block"]}

[{"message":"No such column 'Hello' on sobject of type Account","errorCode":"INVALID_FIELD"}]
```
One line release note: 
- Enhanced error logs for HTTP errors

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested in an error scenario to see if the logs work fine


**Test Configuration**:
* Ballerina Version: SL Beta4
* Operating System: Ubuntu 20.04 LTS
* Java SDK: Java 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
