### PR TITLE
Fix the deprecating issue in the query operation

### DIFF
--- a/salesforce/modules/bulk/tests/utils.bal
+++ b/salesforce/modules/bulk/tests/utils.bal
@@ -74,7 +74,7 @@ function getContactIdByName(string firstName, string lastName, string title) ret
     string contactId = "";
     string sampleQuery = 
     string `SELECT Id FROM Contact WHERE FirstName='${firstName}' AND LastName='${lastName}' AND Title='${title}'`;
-    stream<record{}, error?> queryResults = check restClient->getQueryResult(sampleQuery);
+    stream<record{}, error?> queryResults = check restClient->getQueryResultStream(sampleQuery);
     ResultValue|error? result = queryResults.next();
     if (result is ResultValue) {
         contactId = check result.value.get("Id").ensureType();

--- a/salesforce/rest_client.bal
+++ b/salesforce/rest_client.bal
@@ -396,11 +396,44 @@ public isolated client class Client {
 
     //Query
     # Executes the specified SOQL query.
+    # 
+    # + receivedQuery - Sent SOQL query
+    # + return - `SoqlResult` record if successful. Else, the occurred `Error`.
+    # 
+    # # Deprecated
+    # This function is deprecated as it does not handle the pagination of records
+    # Use the new and improved `getQueryResultStream(string receivedQuery)` function instead. 
+    @display {label: "Get Query Result"}
+    @deprecated
+    isolated remote function getQueryResult(@display {label: "SOQL Query"} string receivedQuery) 
+                                            returns @display {label: "SOQL Result"} SoqlResult|Error {
+        string path = prepareQueryUrl([API_BASE_PATH, QUERY], [Q], [receivedQuery]);
+        json res = check self->getRecord(path);
+        return toSoqlResult(res);
+    }
+
+    # If the query results are too large, retrieve the next batch of results using the nextRecordUrl.
+    # 
+    # + nextRecordsUrl - URL to get the next query results
+    # + return - `SoqlResult` record if successful. Else, the occurred `Error`.
+    # 
+    # # Deprecated
+    # This function is deprecated as it is related to pagination of results in `getQueryResult(string receivedQuery)`
+    # Use the new and improved `getQueryResultStream(string receivedQuery)` function instead.
+    @display {label: "Get Next Query Result"}
+    @deprecated
+    isolated remote function getNextQueryResult(@display {label: "Next Records URL"} string nextRecordsUrl) 
+                                                returns @display {label: "SOQL Result"} SoqlResult|Error {
+        json res = check self->getRecord(nextRecordsUrl);
+        return toSoqlResult(res);
+    }
+
+    # Executes the specified SOQL query.
     #
     # + receivedQuery - Sent SOQL query
-    # + return - `stream<record{}, error?>` if successful. Else, the occurred `error`.
+    # + return - `SoqlResult` record if successful. Else, the occurred `Error`.
     @display {label: "Get Query Result"}
-    isolated remote function getQueryResult(@display {label: "SOQL Query"} string receivedQuery) 
+    isolated remote function getQueryResultStream(@display {label: "SOQL Query"} string receivedQuery) 
                                             returns @display {label: "SOQL Result"} stream<record{}, error?>|error {
         string path = prepareQueryUrl([API_BASE_PATH, QUERY], [Q], [receivedQuery]);
         SOQLQueryResultStream objectInstance = check new (self.salesforceClient, path);
@@ -410,11 +443,28 @@ public isolated client class Client {
 
     //Search
     # Executes the specified SOSL search.
+    # 
+    # + searchString - Sent SOSL search query
+    # + return - `SoslResult` record if successful. Else, the occurred `Error`.
+    # 
+    # # Deprecated
+    # This function is deprecated as it does not handle the pagination of returned data
+    # Use the new and improved `searchSOSLStringStream(string searchString)` function instead.
+    @display {label: "SOSL Search"}
+    @deprecated
+    isolated remote function searchSOSLString(@display {label: "SOSL Search Query"} string searchString) 
+                                              returns @display {label: "SOSL Result"} SoslResult|Error {
+        string path = prepareQueryUrl([API_BASE_PATH, SEARCH], [Q], [searchString]);
+        json res = check self->getRecord(path);
+        return toSoslResult(res);
+    }
+
+    # Executes the specified SOSL search.
     #
     # + searchString - Sent SOSL search query
     # + return - `stream<record{}, error?>` record if successful. Else, the occurred `error`.
     @display {label: "SOSL Search"}
-    isolated remote function searchSOSLString(@display {label: "SOSL Search Query"} string searchString) 
+    isolated remote function searchSOSLStringStream(@display {label: "SOSL Search Query"} string searchString) 
                                               returns @display {label: "SOSL Result"} stream<record{}, error?>|error {
         string path = prepareQueryUrl([API_BASE_PATH, SEARCH], [Q], [searchString]);
         SOSLSearchResult objectInstance = check new (self.salesforceClient, path);

--- a/salesforce/rest_data_mappings.bal
+++ b/salesforce/rest_data_mappings.bal
@@ -108,3 +108,27 @@ isolated function toSObjectBasicInfo(json payload) returns SObjectBasicInfo|Erro
         return error Error(errMsg, res);
     }
 }
+
+isolated function toSoqlResult(json payload) returns SoqlResult|Error {
+    SoqlResult|error res = payload.cloneWithType(SoqlResult);
+
+    if res is SoqlResult {
+        return res;
+    } else {
+        string errMsg = "Error occurred while constructing SoqlResult record.";
+        log:printError(errMsg + " payload:" + payload.toJsonString(), 'error = res);
+        return error Error(errMsg, res);
+    }
+}
+
+isolated function toSoslResult(json payload) returns SoslResult|Error {
+    SoslResult|error res = payload.cloneWithType(SoslResult);
+
+    if res is SoslResult {
+        return res;
+    } else {
+        string errMsg = "Error occurred while constructing SoslResult record.";
+        log:printError(errMsg + " payload:" + payload.toJsonString(), 'error = res);
+        return error Error(errMsg, res);
+    }
+}

--- a/salesforce/rest_types.bal
+++ b/salesforce/rest_types.bal
@@ -92,3 +92,65 @@ public type SObjectBasicInfo record {|
     SObjectMetaData objectDescribe;
     json...;
 |};
+
+# Define the SOQL result type.
+#
+# + done - Query is completed or not
+# + totalSize - The total number result records
+# + records - Result records
+@display{label: "SOQL Result"}
+public type SoqlResult record {|
+    @display{label: "Completed"}
+    boolean done;
+    @display{label: "No of result records"}
+    int totalSize;
+    @display{label: "Records retreived"}
+    SoqlRecord[] records;
+    json...;
+|};
+
+# Defines the SOQL query result record type. 
+#
+# + attributes - Attribute record
+@display{label: "SOQL record"}
+public type SoqlRecord record {|
+    @display{label: "Attributes"}
+    Attribute attributes;
+    json...;
+|};
+
+# Defines SOSL query result.
+#
+# + searchRecords - Matching records for the given search string
+@display{label: "SOSL Result"}
+public type SoslResult record {|
+    @display{label: "Records retrieved"}
+    SoslRecord[] searchRecords;
+    json...;
+|};
+
+# Defines SOSL query result.
+#
+# + attributes - Attribute record
+# + Id - ID of the matching object
+@display{label: "SOSL record"}
+public type SoslRecord record {|
+    @display{label: "Attributes"}
+    Attribute attributes;
+    @display{label: "Id"}
+    string Id;
+    json...;
+|};
+
+# Defines the Attribute type.
+# Contains the attribute information of the resultant record.
+#
+# + type - Type of the resultant record
+# + url - URL of the resultant record
+@display{label: "Attribute"}
+public type Attribute record {|
+    @display{label: "Type"}
+    string 'type;
+    @display{label: "URL"}
+    string url;
+|};

--- a/salesforce/samples/rest_api_usecases/find_record_by_query.bal
+++ b/salesforce/samples/rest_api_usecases/find_record_by_query.bal
@@ -17,7 +17,7 @@
 import ballerina/log;
 import ballerinax/salesforce as sfdc;
 
-public function main() returns error? {
+public function main(){
 
     // Create Salesforce client configuration by reading from config file.
     sfdc:ConnectionConfig sfConfig = {
@@ -31,19 +31,32 @@ public function main() returns error? {
     };
 
     // Create Salesforce client.
-    sfdc:Client baseClient = check new (sfConfig);
-
+    sfdc:Client baseClient = checkpanic new(sfConfig);
+    
+    int totalRecords = 0;
     string sampleQuery = "SELECT name FROM Account";
-    stream<record {}, error?> queryResults = check baseClient->getQueryResult(sampleQuery);
-    int count = check countStream(queryResults);
-    log:printInfo(string `${count} Records Recieved`);
-}
+    sfdc:SoqlResult|sfdc:Error res = baseClient->getQueryResult(sampleQuery);
 
-isolated function countStream(stream<record {}, error?> resultStream) returns int|error {
-    int nLines = 0;
-    check from record{} _ in resultStream
-        do {
-            nLines += 1;
-        };
-    return nLines;
+    if res is sfdc:SoqlResult {
+        if res.totalSize > 0 {
+            totalRecords = res.records.length() ;
+            string nextRecordsUrl = res["nextRecordsUrl"].toString();
+            while (nextRecordsUrl.trim() != "") {
+                log:printInfo("Found new query result set! nextRecordsUrl:" + nextRecordsUrl);
+                sfdc:SoqlResult|sfdc:Error nextRes = baseClient->getNextQueryResult(nextRecordsUrl);
+                
+                if nextRes is sfdc:SoqlResult {
+                    nextRecordsUrl = nextRes["nextRecordsUrl"].toString();
+                    totalRecords = totalRecords + nextRes.records.length();
+                } 
+            }
+            log:printInfo(totalRecords.toString() + " Records Recieved");
+        }
+        else{
+            log:printInfo("No Results Found");
+        }
+        
+    } else {
+        log:printError(msg = res.message());
+    }
 }

--- a/salesforce/samples/rest_api_usecases/find_record_by_query_stream.bal
+++ b/salesforce/samples/rest_api_usecases/find_record_by_query_stream.bal
@@ -1,0 +1,49 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/log;
+import ballerinax/salesforce as sfdc;
+
+public function main() returns error? {
+
+    // Create Salesforce client configuration by reading from config file.
+    sfdc:ConnectionConfig sfConfig = {
+        baseUrl: "<BASE_URL>",
+        clientConfig: {
+            clientId: "<CLIENT_ID>",
+            clientSecret: "<CLIENT_SECRET>",
+            refreshToken: "<REFESH_TOKEN>",
+            refreshUrl: "<REFRESH_URL>"
+        }
+    };
+
+    // Create Salesforce client.
+    sfdc:Client baseClient = check new (sfConfig);
+
+    string sampleQuery = "SELECT name FROM Account";
+    stream<record {}, error?> queryResults = check baseClient->getQueryResult(sampleQuery);
+    int count = check countStream(queryResults);
+    log:printInfo(string `${count} Records Recieved`);
+}
+
+isolated function countStream(stream<record {}, error?> resultStream) returns int|error {
+    int nLines = 0;
+    check from record{} _ in resultStream
+        do {
+            nLines += 1;
+        };
+    return nLines;
+}

--- a/salesforce/stream-implementer.bal
+++ b/salesforce/stream-implementer.bal
@@ -117,14 +117,14 @@ type Record record {};
 type SoqlQueryResult record {|
     boolean done;
     int totalSize;
-    SoqlRecord[] records;
+    SoqlRecordData[] records;
     json...;
 |};
 
 # Defines the SOQL query result record type. 
 #
 # + attributes - Attribute record
-type SoqlRecord record {|
+type SoqlRecordData record {|
     Attribute attributes?;
     json...;
 |};
@@ -133,26 +133,19 @@ type SoqlRecord record {|
 #
 # + searchRecords - Matching records for the given search string
 type SoslSearchResult record {|
-    SoslRecord[] searchRecords;
+    SoslRecordData[] searchRecords;
     json...;
 |};
+
 
 # Defines SOSL query result.
 #
 # + attributes - Attribute record
 # + Id - ID of the matching object
-type SoslRecord record {|
+type SoslRecordData record {|
     Attribute attributes;
     string Id;
     json...;
 |};
 
-# Defines the Attribute type.
-# Contains the attribute information of the resultant record.
-#
-# + type - Type of the resultant record
-# + url - URL of the resultant record
-type Attribute record {|
-    string 'type;
-    string url;
-|};
+


### PR DESCRIPTION
# Description
$subject

Related Pull Requests
- https://github.com/ballerina-platform/module-ballerinax-sfdc/pull/251


One line release note: 
- Fix the connector by deprecating the `getQueryResult` and `searchSOSLString` operations
- Introduce `getQueryResultStream` and `searchSOSLStringStream`  for the `getQueryResult` and `searchSOSLString` operations respectively

## Type of change

Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Test Configuration**:
* Ballerina Version: 2201.0.2
* Operating System:
* Java SDK: 

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
