### PR TITLE
Fix test dependencies for queryCsv test

### DIFF
--- a/salesforce/modules/bulk/tests/bulk_csv_query.bal
+++ b/salesforce/modules/bulk/tests/bulk_csv_query.bal
@@ -20,7 +20,7 @@ import ballerina/lang.runtime;
 
 @test:Config {
     enable: true,
-    dependsOn: [updateCsv, insertCsvFromFile, insertCsv]
+    dependsOn: [updateCsv, insertCsvFromFile, insertCsv, insertCsvStringArrayFromFile, insertCsvStreamFromFile]
 }
 function queryCsv() returns error? {
     runtime:sleep(delayInSecs);


### PR DESCRIPTION
# Description
`queryCsv` test was failing in the daily build.
I found that the `insertCsvStringArrayFromFile, insertCsvStreamFromFile` tests have to run before the `queryCsv`.
Hence updated the dependencies of `queryCsv` test accordingly.

