### PR TITLE
[2201.3.x] Add report related operations

### DIFF
--- a/salesforce/Dependencies.toml
+++ b/salesforce/Dependencies.toml
@@ -33,7 +33,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -63,7 +63,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.5.0"
+version = "2.5.3"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -243,7 +243,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -257,7 +257,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -279,7 +279,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -299,7 +299,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -375,7 +375,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "salesforce"
-version = "7.2.0"
+version = "7.3.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},

--- a/salesforce/client.bal
+++ b/salesforce/client.bal
@@ -245,6 +245,71 @@ public isolated client class Client {
         return check self.salesforceClient->delete(path);
     }
 
+    # Lists reports.
+    #
+    # + return - Array of Report if successful or else `error`
+    @display {label: "List Reports"}
+    isolated remote function listReports() returns @display {label: "Reports"} Report[]|error {
+        string path = utils:prepareUrl([API_BASE_PATH, ANALYTICS, REPORTS]);
+        return check self.salesforceClient->get(path);
+    }
+
+    # Deletes a report.
+    #
+    # + reportId - Report Id
+    # + return - `()` if the report deletion is successful or else an error
+    @display {label: "Delete Report"}
+    isolated remote function deleteReport(@display {label: "Report Id"} string reportId) returns error? {
+        string path = utils:prepareUrl([API_BASE_PATH, ANALYTICS, REPORTS, reportId]);
+        return check self.salesforceClient->delete(path);
+    }
+
+    # Runs an instance of a report synchronously.
+    #
+    # + reportId - Report Id
+    # + return - ReportInstanceResult if successful or else `error`
+    @display {label: "Run Report Synchronously"}
+    isolated remote function runReportSync(@display {label: "Report Id"} string reportId)
+            returns @display {label: "Report Instance Result"} ReportInstanceResult|error {
+        string path = utils:prepareUrl([API_BASE_PATH, ANALYTICS, REPORTS, reportId]);
+        return check self.salesforceClient->get(path);
+    }
+
+    # Runs an instance of a report asynchronously.
+    #
+    # + reportId - Report Id
+    # + return - ReportInstance if successful or else `error`
+    @display {label: "Run Report Asynchronously"}
+    isolated remote function runReportAsync(@display {label: "Report Id"} string reportId)
+            returns @display {label: "Report Instance"} ReportInstance|error {
+        string path = utils:prepareUrl([API_BASE_PATH, ANALYTICS, REPORTS, reportId, INSTANCES]);
+        return check self.salesforceClient->post(path, {});
+    }
+
+    # Lists asynchronous runs of a Report.
+    #
+    # + reportId - Report Id
+    # + return - Array of ReportInstance if successful or else `error`
+    @display {label: "List Async Report Runs"}
+    isolated remote function listAsyncRunsOfReport(@display {label: "Report Id"} string reportId)
+            returns @display {label: "Report Instances"} ReportInstance[]|error {
+        string path = utils:prepareUrl([API_BASE_PATH, ANALYTICS, REPORTS, reportId, INSTANCES]);
+        return check self.salesforceClient->get(path);
+    }
+
+    # Get report instance result.
+    #
+    # + reportId - Report Id
+    # + instanceId - Instance Id
+    # + return - ReportInstanceResult if successful or else `error`
+    @display {label: "Get Report Instance Result"}
+    isolated remote function getReportInstanceResult(@display {label: "Report Id"} string reportId, 
+            @display {label: "Instance Id"} string instanceId) returns @display {label: "Report Instance Result"} 
+            ReportInstanceResult|error {
+        string path = utils:prepareUrl([API_BASE_PATH, ANALYTICS, REPORTS, reportId, INSTANCES, instanceId]);
+        return check self.salesforceClient->get(path);
+    }
+
     # Executes the specified SOQL query.
     #
     # + soql - SOQL query

--- a/salesforce/constants.bal
+++ b/salesforce/constants.bal
@@ -29,6 +29,15 @@ const string BASE_PATH = "/services/data";
 # Constant field `API_BASE_PATH`. Holds the value for the Salesforce API base path/URL.
 final string API_BASE_PATH = string `${BASE_PATH}/${API_VERSION}`;
 
+# Constant field `ANALYTICS`. Holds the value analytics for analytics resource prefix.
+const string ANALYTICS = "analytics";
+
+# Constant field `INSTANCES`. Holds the value instances for instances resource prefix.
+const string INSTANCES = "instances";
+
+# Constant field `REPORTS`. Holds the value reports for reports resource prefix.
+const string REPORTS = "reports";
+
 # Constant field `SOBJECTS`. Holds the value sobjects for get sobject resource prefix.
 const string SOBJECTS = "sobjects";
 

--- a/salesforce/types.bal
+++ b/salesforce/types.bal
@@ -199,3 +199,100 @@ public type CreationResponse record {
     anydata[] errors;
     boolean success;
 };
+
+# Represents a Report
+#
+# + id - Unique report ID  
+# + name - Report display name  
+# + url - URL that returns report data  
+# + describeUrl - URL that retrieves report metadata  
+# + instancesUrl - Information for each instance of the report that was run asynchronously.
+public type Report record {
+    string id;
+    string name;
+    string url;
+    string describeUrl;
+    string instancesUrl;
+};
+
+# Represents an instance of a Report
+#
+# + id - Unique ID for a report instance
+# + status - Status of the report run
+# + requestDate - Date and time when an instance of the report run was requested
+# + completionDate - Date, time when the instance of the report run finished
+# + url - URL where results of the report run for that instance are stored
+# + ownerId - API name of the user that created the instance
+# + queryable - Indicates if it is queryable
+# + hasDetailRows - Indicates if it has detailed data
+public type ReportInstance record {
+    string id;
+    string status;
+    string requestDate;
+    string? completionDate;
+    string url;
+    string ownerId;
+    boolean queryable;
+    boolean hasDetailRows;
+};
+
+# Represents attributes of instance of an asynchronous report run
+#
+# + id - Unique ID for an instance of a report that was run  
+# + reportId - Unique report ID
+# + reportName - Display name of the report
+# + status - Status of the report run
+# + ownerId - API name of the user that created the instance
+# + requestDate - Date and time when an instance of the report run was requested 
+# + 'type - Format of the resource
+# + completionDate - Date, time when the instance of the report run finished
+# + errorMessage - Error message if the instance run failed
+# + queryable - Indicates if it is queryable
+public type AsyncReportAttributes record {
+    string id;
+    string reportId;
+    string reportName;
+    string status;
+    string ownerId;
+    string requestDate;
+    string 'type;
+    string? completionDate;
+    string? errorMessage;
+    boolean queryable;
+};
+
+# Represents attributes of instance of synchronous report run
+#
+# + reportId - Unique report ID  
+# + reportName - Display name of the report  
+# + 'type - API resource format  
+# + describeUrl - Resource URL to get report metadata  
+# + instancesUrl - Resource URL to run a report asynchronously
+public type SyncReportAttributes record {
+    string reportId;
+    string reportName;
+    string 'type;
+    string describeUrl;
+    string instancesUrl;
+};
+
+# Represents result of an asynchronous report run
+#
+# + attributes - Attributes for the instance of the report run
+# + allData - Indicates if all report results are returned
+# + factMap - Collection of summary level data or both detailed and summary level data
+# + groupingsAcross - Collection of column groupings
+# + groupingsDown - Collection of row groupings
+# + reportMetadata - Information about the fields used to build the report
+# + hasDetailRows - Indicates if it has detailed data
+# + reportExtendedMetadata - Information on report groupings, summary fields, and detailed data columns
+public type ReportInstanceResult record {
+    AsyncReportAttributes|SyncReportAttributes attributes;
+    boolean allData;
+    map<json> factMap;
+    map<json> groupingsAcross;
+    map<json> groupingsDown;
+    map<json> reportMetadata;
+    boolean hasDetailRows;
+    map<json>? reportExtendedMetadata;
+};


### PR DESCRIPTION
# Description
Add the following operations related to Reports
1. listReports
2. deleteReport
3. runReportSunc
4. runReportAsync
5. listAsyncRunsOfReport
6. getReportInstanceResult

- Fix https://github.com/wso2-enterprise/choreo/issues/18319
- Fix https://github.com/ballerina-platform/ballerina-extended-library/issues/490

One line release note: 
- Add report related operations

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

