### PR TITLE
Update GraalVM workflow with new command option

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -49,7 +49,7 @@ jobs:
                 version: latest
 
             - name: Run Ballerina tests using the native executable
-              run: bal test --native ./salesforce
+              run: bal test --graalvm ./salesforce
               env:
                 JAVA_HOME: /usr/lib/jvm/default-jvm
                 CLIENT_ID: ${{ secrets.CLIENT_ID }}


### PR DESCRIPTION
This PR will rename the command option in the graalVM workflow from --native to --graalvm. Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/531