### PR TITLE
Support mTLS in Salesforce listener

### DIFF
--- a/ballerina/data_types.bal
+++ b/ballerina/data_types.bal
@@ -62,6 +62,8 @@ public type CommonListenerConfig record {|
     decimal keepAliveInterval = 120;
     # The Salesforce API version to use for Streaming API
     string apiVersion = "43.0";
+    # Configurations for mutual TLS authentication
+    http:ClientSecureSocket secureSocket?;
 |};
 
 # The replay options representing the point in time when events are read.

--- a/build-config/spotbugs-exclude.xml
+++ b/build-config/spotbugs-exclude.xml
@@ -60,5 +60,30 @@
         <Bug code="SIC" />
         <Package name="io.ballerinax.salesforce" />
     </Match>
+
+
+    <Match>
+        <Bug code="EI2" />
+        <Class name="io.ballerinax.salesforce.OAuth2BayeuxParameters" />
+        <Method name="&lt;init&gt;" />
+    </Match>
+
+    <Match>
+        <Bug code="EI" />
+        <Class name="io.ballerinax.salesforce.OAuth2BayeuxParameters" />
+        <Method name="sslContextFactory" />
+    </Match>
+
+    <Match>
+        <Bug code="EI2" />
+        <Class name="io.ballerinax.salesforce.BasicBayeuxParameters" />
+        <Method name="&lt;init&gt;" />
+    </Match>
+
+    <Match>
+        <Bug code="EI" />
+        <Class name="io.ballerinax.salesforce.BasicBayeuxParameters" />
+        <Method name="sslContextFactory" />
+    </Match>
 </FindBugsFilter>
 

--- a/native/src/main/java/io/ballerinax/salesforce/BasicBayeuxParameters.java
+++ b/native/src/main/java/io/ballerinax/salesforce/BasicBayeuxParameters.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerinax.salesforce;
+
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import java.net.URL;
+
+/**
+ * Initial BayeuxParameters used before authentication and endpoint establishment.
+ */
+public class BasicBayeuxParameters implements BayeuxParameters {
+
+    private final String apiVersion;
+    private final SslContextFactory sslContextFactory;
+
+    public BasicBayeuxParameters(String apiVersion) {
+        this.apiVersion = apiVersion;
+        this.sslContextFactory = null;
+    }
+
+    public BasicBayeuxParameters(String apiVersion, SslContextFactory sslContextFactory) {
+        this.apiVersion = apiVersion;
+        this.sslContextFactory = sslContextFactory;
+    }
+
+    @Override
+    public String bearerToken() {
+        throw new IllegalStateException("Have not authenticated");
+    }
+
+    @Override
+    public URL endpoint() {
+        throw new IllegalStateException("Have not established replay endpoint");
+    }
+
+    @Override
+    public String version() {
+        return apiVersion;
+    }
+
+    @Override
+    public SslContextFactory sslContextFactory() {
+        if (sslContextFactory != null) {
+            return sslContextFactory;
+        }
+        return BayeuxParameters.super.sslContextFactory();
+    }
+}

--- a/native/src/main/java/io/ballerinax/salesforce/BayeuxParameters.java
+++ b/native/src/main/java/io/ballerinax/salesforce/BayeuxParameters.java
@@ -114,7 +114,9 @@ public interface BayeuxParameters {
      * @return the SslContextFactory for establishing secure outbound connections
      */
     default SslContextFactory sslContextFactory() {
-        return new SslContextFactory();
+        SslContextFactory.Client factory = new SslContextFactory.Client();
+        factory.setEndpointIdentificationAlgorithm("HTTPS");
+        return factory;
     }
 
     /**

--- a/native/src/main/java/io/ballerinax/salesforce/BayeuxParameters.java
+++ b/native/src/main/java/io/ballerinax/salesforce/BayeuxParameters.java
@@ -40,6 +40,8 @@ import java.util.concurrent.TimeUnit;
  */
 public interface BayeuxParameters {
 
+    String HTTPS_ENDPOINT_ID_ALGORITHM = "HTTPS";
+
     /**
      * @return the bearer token used to authenticate
      */
@@ -115,7 +117,7 @@ public interface BayeuxParameters {
      */
     default SslContextFactory sslContextFactory() {
         SslContextFactory.Client factory = new SslContextFactory.Client();
-        factory.setEndpointIdentificationAlgorithm("HTTPS");
+        factory.setEndpointIdentificationAlgorithm(HTTPS_ENDPOINT_ID_ALGORITHM);
         return factory;
     }
 

--- a/native/src/main/java/io/ballerinax/salesforce/EmpConnector.java
+++ b/native/src/main/java/io/ballerinax/salesforce/EmpConnector.java
@@ -308,7 +308,7 @@ public class EmpConnector {
         } catch (Exception e) {
             log.error("Unable to start HTTP transport[{}]", parameters.endpoint(), e);
             running.set(false);
-            future.complete(false);
+            future.completeExceptionally(e);
             return future;
         }
 

--- a/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
+++ b/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
@@ -160,6 +160,7 @@ public class ListenerUtil {
 
     private static SslContextFactory buildSslContextFactory(BObject listener) {
         SslContextFactory.Client factory = new SslContextFactory.Client();
+        factory.setEndpointIdentificationAlgorithm("HTTPS");
         String keystorePath = (String) listener.getNativeData(KEYSTORE_PATH);
         if (keystorePath != null) {
             factory.setKeyStorePath(keystorePath);

--- a/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
+++ b/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
@@ -65,33 +65,43 @@ import static io.ballerinax.salesforce.Constants.REPLAY_FROM;
  * Util class containing the java external functions for Ballerina Salesforce listener.
  */
 public class ListenerUtil {
-    public static final String IS_OAUTH2 = "isOAuth2";
-    public static final String BASE_URL = "baseUrl";
-    public static final String CONNECTION_TIMEOUT = "connectionTimeout";
-    public static final String READ_TIMEOUT = "readTimeout";
-    public static final String KEEP_ALIVE_INTERVAL = "keepAliveInterval";
-    public static final String API_VERSION = "apiVersion";
-    public static final String KEYSTORE_PATH = "secureSocket_keystore_path";
-    public static final String KEYSTORE_PASSWORD = "secureSocket_keystore_password";
-    public static final String KEYSTORE_CERT_FILE = "secureSocket_certkey_certFile";
-    public static final String KEYSTORE_KEY_FILE = "secureSocket_certkey_keyFile";
-    public static final String KEYSTORE_KEY_PASSWORD = "secureSocket_certkey_keyPassword";
-    public static final String TRUSTSTORE_PATH = "secureSocket_truststore_path";
-    public static final String TRUSTSTORE_PASSWORD = "secureSocket_truststore_password";
-    public static final String TRUSTSTORE_CERT_FILE = "secureSocket_cert_file";
+    private static final String IS_OAUTH2 = "isOAuth2";
+    private static final String BASE_URL = "baseUrl";
+    private static final String CONNECTION_TIMEOUT = "connectionTimeout";
+    private static final String READ_TIMEOUT = "readTimeout";
+    private static final String KEEP_ALIVE_INTERVAL = "keepAliveInterval";
+    private static final String API_VERSION = "apiVersion";
+    private static final String SSL_CONTEXT_FACTORY = "sslContextFactory";
     private static final ArrayList<BObject> services = new ArrayList<>();
     private static final Map<BObject, DispatcherService> serviceDispatcherMap = new HashMap<>();
-    public static final String GET_OAUTH2_TOKEN_METHOD = "getOAuth2Token";
-    public static final BString FIELD_PATH = StringUtils.fromString("path");
-    public static final BString FIELD_PASSWORD = StringUtils.fromString("password");
-    public static final BString FIELD_CERT_FILE = StringUtils.fromString("certFile");
-    public static final BString FIELD_KEY_FILE = StringUtils.fromString("keyFile");
-    public static final BString FIELD_KEY_PASSWORD = StringUtils.fromString("keyPassword");
-    public static final BString KEYSTORE_CONFIG = StringUtils.fromString("key");
-    public static final BString TRUSTSTORE_CONFIG = StringUtils.fromString("cert");
-    public static final String X_509 = "X.509";
+    private static final String GET_OAUTH2_TOKEN_METHOD = "getOAuth2Token";
+    private static final BString FIELD_PATH = StringUtils.fromString("path");
+    private static final BString FIELD_PASSWORD = StringUtils.fromString("password");
+    private static final BString FIELD_CERT_FILE = StringUtils.fromString("certFile");
+    private static final BString FIELD_KEY_FILE = StringUtils.fromString("keyFile");
+    private static final BString FIELD_KEY_PASSWORD = StringUtils.fromString("keyPassword");
+    private static final BString KEYSTORE_CONFIG = StringUtils.fromString("key");
+    private static final BString TRUSTSTORE_CONFIG = StringUtils.fromString("cert");
+    private static final String X_509 = "X.509";
+    private static final String HTTPS_ENDPOINT_ID_ALGORITHM = "HTTPS";
+    private static final String[] SUPPORTED_KEY_ALGORITHMS = {"RSA", "EC", "DSA"};
+    private static final long MILLIS_PER_SECOND = 1000L;
     private static EmpConnector connector;
     private static TopicSubscription subscription;
+
+    private static long secondsToMilliseconds(BDecimal seconds) {
+        return seconds.value().multiply(BigDecimal.valueOf(MILLIS_PER_SECOND)).longValue();
+    }
+
+    private static SslContextFactory getSslContextFactory(BObject listener) {
+        SslContextFactory stored = (SslContextFactory) listener.getNativeData(SSL_CONTEXT_FACTORY);
+        if (stored != null) {
+            return stored;
+        }
+        SslContextFactory.Client factory = new SslContextFactory.Client();
+        factory.setEndpointIdentificationAlgorithm(HTTPS_ENDPOINT_ID_ALGORITHM);
+        return factory;
+    }
 
     private static void extractBaseConfigs(BObject listener, int replayFrom,
             BDecimal connectionTimeout, BDecimal readTimeout, BDecimal keepAliveInterval,
@@ -100,9 +110,9 @@ public class ListenerUtil {
         listener.addNativeData(DISPATCHERS, serviceDispatcherMap);
         listener.addNativeData(REPLAY_FROM, replayFrom);
         listener.addNativeData(API_VERSION, apiVersion.getValue());
-        long connectionTimeoutMs = connectionTimeout.value().multiply(BigDecimal.valueOf(1000)).longValue();
-        long readTimeoutMs = readTimeout.value().multiply(BigDecimal.valueOf(1000)).longValue();
-        long keepAliveIntervalMs = keepAliveInterval.value().multiply(BigDecimal.valueOf(1000)).longValue();
+        long connectionTimeoutMs = secondsToMilliseconds(connectionTimeout);
+        long readTimeoutMs = secondsToMilliseconds(readTimeout);
+        long keepAliveIntervalMs = secondsToMilliseconds(keepAliveInterval);
         listener.addNativeData(CONNECTION_TIMEOUT, connectionTimeoutMs);
         listener.addNativeData(READ_TIMEOUT, readTimeoutMs);
         listener.addNativeData(KEEP_ALIVE_INTERVAL, keepAliveIntervalMs);
@@ -117,81 +127,50 @@ public class ListenerUtil {
         listener.addNativeData(IS_OAUTH2, false);
         listener.addNativeData(IS_SAND_BOX, isSandBox);
         if (secureSocket != null) {
-            extractSecureSocketConfig(listener, (BMap<?, ?>) secureSocket);
+            listener.addNativeData(SSL_CONTEXT_FACTORY, buildSslContextFactory((BMap<?, ?>) secureSocket));
         }
     }
 
-    public static void initListener(BObject listener, int replayFrom, BString baseUrl, BDecimal connectionTimeout,
-                                    BDecimal readTimeout, BDecimal keepAliveInterval, BString apiVersion,
-                                    Object secureSocket) {
+    public static void initListener(BObject listener, int replayFrom, BString baseUrl,
+            BDecimal connectionTimeout, BDecimal readTimeout, BDecimal keepAliveInterval, BString apiVersion,
+            Object secureSocket) {
         extractBaseConfigs(listener, replayFrom, connectionTimeout, readTimeout, keepAliveInterval, apiVersion);
         listener.addNativeData(IS_OAUTH2, true);
         listener.addNativeData(BASE_URL, baseUrl.getValue());
         if (secureSocket != null) {
-            extractSecureSocketConfig(listener, (BMap<?, ?>) secureSocket);
+            listener.addNativeData(SSL_CONTEXT_FACTORY, buildSslContextFactory((BMap<?, ?>) secureSocket));
         }
     }
 
-    private static void extractSecureSocketConfig(BObject listener, BMap<?, ?> secureSocketMap) {
+    private static SslContextFactory buildSslContextFactory(BMap<?, ?> secureSocketMap) {
+        SslContextFactory.Client factory = new SslContextFactory.Client();
+        factory.setEndpointIdentificationAlgorithm(HTTPS_ENDPOINT_ID_ALGORITHM);
+
         BMap<?, ?> keyField = secureSocketMap.getMapValue(KEYSTORE_CONFIG);
         if (keyField != null && keyField.containsKey(FIELD_PATH)) {
-            BString path = keyField.getStringValue(FIELD_PATH);
-            BString password = keyField.getStringValue(FIELD_PASSWORD);
-            listener.addNativeData(KEYSTORE_PATH, path.getValue());
-            listener.addNativeData(KEYSTORE_PASSWORD, password.getValue());
+            factory.setKeyStorePath(keyField.getStringValue(FIELD_PATH).getValue());
+            factory.setKeyStorePassword(keyField.getStringValue(FIELD_PASSWORD).getValue());
         } else if (keyField != null && keyField.containsKey(FIELD_CERT_FILE)) {
-            BString certFile = keyField.getStringValue(FIELD_CERT_FILE);
-            BString keyFile = keyField.getStringValue(FIELD_KEY_FILE);
-            listener.addNativeData(KEYSTORE_CERT_FILE, certFile.getValue());
-            listener.addNativeData(KEYSTORE_KEY_FILE, keyFile.getValue());
+            String certFile = keyField.getStringValue(FIELD_CERT_FILE).getValue();
+            String keyFilePath = keyField.getStringValue(FIELD_KEY_FILE).getValue();
             BString keyPassword = keyField.getStringValue(FIELD_KEY_PASSWORD);
-            if (keyPassword != null) {
-                listener.addNativeData(KEYSTORE_KEY_PASSWORD, keyPassword.getValue());
-            }
-        }
-        Object certField = secureSocketMap.get(TRUSTSTORE_CONFIG);
-        if (certField instanceof BMap<?, ?> certMap) {
-            BString path = certMap.getStringValue(FIELD_PATH);
-            BString password = certMap.getStringValue(FIELD_PASSWORD);
-            listener.addNativeData(TRUSTSTORE_PATH, path.getValue());
-            listener.addNativeData(TRUSTSTORE_PASSWORD, password.getValue());
-        } else if (certField instanceof BString) {
-            listener.addNativeData(TRUSTSTORE_CERT_FILE, ((BString) certField).getValue());
-        }
-    }
-
-    private static SslContextFactory buildSslContextFactory(BObject listener) {
-        SslContextFactory.Client factory = new SslContextFactory.Client();
-        factory.setEndpointIdentificationAlgorithm("HTTPS");
-        String keystorePath = (String) listener.getNativeData(KEYSTORE_PATH);
-        if (keystorePath != null) {
-            factory.setKeyStorePath(keystorePath);
-            factory.setKeyStorePassword((String) listener.getNativeData(KEYSTORE_PASSWORD));
-        }
-        String certKeyFile = (String) listener.getNativeData(KEYSTORE_CERT_FILE);
-        if (certKeyFile != null) {
-            String keyFile = (String) listener.getNativeData(KEYSTORE_KEY_FILE);
-            String keyPassword = (String) listener.getNativeData(KEYSTORE_KEY_PASSWORD);
-            char[] keyPasswordChars = keyPassword != null ? keyPassword.toCharArray() : new char[0];
+            char[] keyPasswordChars = keyPassword != null ? keyPassword.getValue().toCharArray() : new char[0];
             try {
-                KeyStore keystore = buildKeyStoreFromPem(certKeyFile, keyFile, keyPasswordChars);
+                KeyStore keystore = buildKeyStoreFromPem(certFile, keyFilePath, keyPasswordChars);
                 factory.setKeyStore(keystore);
-                factory.setKeyStorePassword(keyPassword != null ? keyPassword : "");
+                factory.setKeyStorePassword(keyPassword != null ? keyPassword.getValue() : "");
             } catch (GeneralSecurityException | IOException e) {
                 throw new IllegalArgumentException("Failed to load the keystore: " + e.getMessage(), e);
             }
         }
 
-        String truststorePath = (String) listener.getNativeData(TRUSTSTORE_PATH);
-        if (truststorePath != null) {
-            factory.setTrustStorePath(truststorePath);
-            factory.setTrustStorePassword((String) listener.getNativeData(TRUSTSTORE_PASSWORD));
-        }
-        String certFilePath = (String) listener.getNativeData(TRUSTSTORE_CERT_FILE);
-        if (certFilePath != null) {
+        Object certField = secureSocketMap.get(TRUSTSTORE_CONFIG);
+        if (certField instanceof BMap<?, ?> certMap) {
+            factory.setTrustStorePath(certMap.getStringValue(FIELD_PATH).getValue());
+            factory.setTrustStorePassword(certMap.getStringValue(FIELD_PASSWORD).getValue());
+        } else if (certField instanceof BString trustCert) {
             try {
-                KeyStore ts = buildTrustStoreFromPem(certFilePath);
-                factory.setTrustStore(ts);
+                factory.setTrustStore(buildTrustStoreFromPem(trustCert.getValue()));
             } catch (GeneralSecurityException | IOException e) {
                 throw new IllegalArgumentException("Failed to load the truststore: " + e.getMessage(), e);
             }
@@ -217,7 +196,7 @@ public class ListenerUtil {
 
     private static PrivateKey loadPrivateKey(byte[] keyBytes) throws GeneralSecurityException {
         PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
-        for (String algorithm : new String[]{"RSA", "EC", "DSA"}) {
+        for (String algorithm : SUPPORTED_KEY_ALGORITHMS) {
             try {
                 return KeyFactory.getInstance(algorithm).generatePrivate(spec);
             } catch (InvalidKeySpecException ignored) { // ignore and try next algorithm
@@ -277,12 +256,7 @@ public class ListenerUtil {
         long readTimeoutMs = (Long) listener.getNativeData(READ_TIMEOUT);
         long keepAliveIntervalMs = (Long) listener.getNativeData(KEEP_ALIVE_INTERVAL);
         String apiVersion = (String) listener.getNativeData(API_VERSION);
-        SslContextFactory sslContextFactory;
-        try {
-            sslContextFactory = buildSslContextFactory(listener);
-        } catch (IllegalArgumentException e) {
-            return sfdcError(e.getMessage(), e.getCause());
-        }
+        SslContextFactory sslContextFactory = getSslContextFactory(listener);
 
         BearerTokenProvider tokenProvider = new BearerTokenProvider(() -> {
             try {
@@ -309,12 +283,7 @@ public class ListenerUtil {
         long readTimeoutMs = (Long) listener.getNativeData(READ_TIMEOUT);
         long keepAliveIntervalMs = (Long) listener.getNativeData(KEEP_ALIVE_INTERVAL);
         String apiVersion = (String) listener.getNativeData(API_VERSION);
-        SslContextFactory sslContextFactory;
-        try {
-            sslContextFactory = buildSslContextFactory(listener);
-        } catch (IllegalArgumentException e) {
-            return sfdcError(e.getMessage(), e.getCause());
-        }
+        SslContextFactory sslContextFactory = getSslContextFactory(listener);
 
         BearerTokenProvider tokenProvider = new BearerTokenProvider(() ->
             new OAuth2BayeuxParameters(() -> getOAuth2Token(env, listener), baseUrl,

--- a/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
+++ b/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
@@ -89,7 +89,7 @@ public class ListenerUtil {
     private static EmpConnector connector;
     private static TopicSubscription subscription;
 
-    private static long secondsToMilliseconds(BDecimal seconds) {
+    private static long convertToMilliseconds(BDecimal seconds) {
         return seconds.value().multiply(BigDecimal.valueOf(MILLIS_PER_SECOND)).longValue();
     }
 
@@ -110,9 +110,9 @@ public class ListenerUtil {
         listener.addNativeData(DISPATCHERS, serviceDispatcherMap);
         listener.addNativeData(REPLAY_FROM, replayFrom);
         listener.addNativeData(API_VERSION, apiVersion.getValue());
-        long connectionTimeoutMs = secondsToMilliseconds(connectionTimeout);
-        long readTimeoutMs = secondsToMilliseconds(readTimeout);
-        long keepAliveIntervalMs = secondsToMilliseconds(keepAliveInterval);
+        long connectionTimeoutMs = convertToMilliseconds(connectionTimeout);
+        long readTimeoutMs = convertToMilliseconds(readTimeout);
+        long keepAliveIntervalMs = convertToMilliseconds(keepAliveInterval);
         listener.addNativeData(CONNECTION_TIMEOUT, connectionTimeoutMs);
         listener.addNativeData(READ_TIMEOUT, readTimeoutMs);
         listener.addNativeData(KEEP_ALIVE_INTERVAL, keepAliveIntervalMs);

--- a/native/src/main/java/io/ballerinax/salesforce/LoginHelper.java
+++ b/native/src/main/java/io/ballerinax/salesforce/LoginHelper.java
@@ -132,47 +132,13 @@ public class LoginHelper {
 
     public static BayeuxParameters login(URL loginEndpoint, String username,
             String password, String apiVersion) throws Exception {
-        return login(loginEndpoint, username, password, new BayeuxParameters() {
-            @Override
-            public String bearerToken() {
-                throw new IllegalStateException("Have not authenticated");
-            }
-
-            @Override
-            public URL endpoint() {
-                throw new IllegalStateException("Have not established replay endpoint");
-            }
-
-            @Override
-            public String version() {
-                return apiVersion;
-            }
-        }, apiVersion);
+        return login(loginEndpoint, username, password, new BasicBayeuxParameters(apiVersion), apiVersion);
     }
 
     public static BayeuxParameters login(URL loginEndpoint, String username,
             String password, String apiVersion, SslContextFactory sslContextFactory) throws Exception {
-        return login(loginEndpoint, username, password, new BayeuxParameters() {
-            @Override
-            public String bearerToken() {
-                throw new IllegalStateException("Have not authenticated");
-            }
-
-            @Override
-            public URL endpoint() {
-                throw new IllegalStateException("Have not established replay endpoint");
-            }
-
-            @Override
-            public String version() {
-                return apiVersion;
-            }
-
-            @Override
-            public SslContextFactory sslContextFactory() {
-                return sslContextFactory;
-            }
-        }, apiVersion);
+        return login(loginEndpoint, username, password,
+                new BasicBayeuxParameters(apiVersion, sslContextFactory), apiVersion);
     }
 
     public static BayeuxParameters login(URL loginEndpoint, String username, String password,

--- a/native/src/main/java/io/ballerinax/salesforce/LoginHelper.java
+++ b/native/src/main/java/io/ballerinax/salesforce/LoginHelper.java
@@ -28,6 +28,7 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.util.ByteBufferContentProvider;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -115,14 +116,21 @@ public class LoginHelper {
     private static final String SERVICES_SOAP_PARTNER_ENDPOINT_PREFIX = "/services/Soap/u/";
     private static final String SERVICES_SOAP_PARTNER_ENDPOINT_SUFFIX = "/";
 
-    public static BayeuxParameters login(String username, String password, 
-        BObject listener, String apiVersion) throws Exception {
+    public static BayeuxParameters login(String username, String password,
+            BObject listener, String apiVersion) throws Exception {
         boolean isSandBox = (Boolean) listener.getNativeData(IS_SAND_BOX);
         String endpoint = getLoginEndpoint(isSandBox);
         return login(new URL(endpoint), username, password, apiVersion);
     }
 
-    public static BayeuxParameters login(URL loginEndpoint, String username, 
+    public static BayeuxParameters login(String username, String password,
+            BObject listener, String apiVersion, SslContextFactory sslContextFactory) throws Exception {
+        boolean isSandBox = (Boolean) listener.getNativeData(IS_SAND_BOX);
+        String endpoint = getLoginEndpoint(isSandBox);
+        return login(new URL(endpoint), username, password, apiVersion, sslContextFactory);
+    }
+
+    public static BayeuxParameters login(URL loginEndpoint, String username,
             String password, String apiVersion) throws Exception {
         return login(loginEndpoint, username, password, new BayeuxParameters() {
             @Override
@@ -138,6 +146,31 @@ public class LoginHelper {
             @Override
             public String version() {
                 return apiVersion;
+            }
+        }, apiVersion);
+    }
+
+    public static BayeuxParameters login(URL loginEndpoint, String username,
+            String password, String apiVersion, SslContextFactory sslContextFactory) throws Exception {
+        return login(loginEndpoint, username, password, new BayeuxParameters() {
+            @Override
+            public String bearerToken() {
+                throw new IllegalStateException("Have not authenticated");
+            }
+
+            @Override
+            public URL endpoint() {
+                throw new IllegalStateException("Have not established replay endpoint");
+            }
+
+            @Override
+            public String version() {
+                return apiVersion;
+            }
+
+            @Override
+            public SslContextFactory sslContextFactory() {
+                return sslContextFactory;
             }
         }, apiVersion);
     }

--- a/native/src/main/java/io/ballerinax/salesforce/OAuth2BayeuxParameters.java
+++ b/native/src/main/java/io/ballerinax/salesforce/OAuth2BayeuxParameters.java
@@ -18,6 +18,8 @@
 
 package io.ballerinax.salesforce;
 
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
@@ -27,19 +29,22 @@ import java.util.function.Supplier;
  * Implementation of BayeuxParameters for OAuth2 authentication.
  */
 public class OAuth2BayeuxParameters implements BayeuxParameters {
-   private final Supplier<String> tokenSupplier;
+    private final Supplier<String> tokenSupplier;
     private final String baseUrl;
     private final long readTimeoutMs;
     private final long keepAliveIntervalMs;
     private final String apiVersion;
+    private final SslContextFactory sslContextFactory;
 
     public OAuth2BayeuxParameters(Supplier<String> tokenSupplier, String baseUrl,
-        long readTimeoutMs, long keepAliveIntervalMs, String apiVersion) {
+            long readTimeoutMs, long keepAliveIntervalMs, String apiVersion,
+            SslContextFactory sslContextFactory) {
         this.tokenSupplier = tokenSupplier;
         this.baseUrl = baseUrl;
         this.readTimeoutMs = readTimeoutMs;
         this.keepAliveIntervalMs = keepAliveIntervalMs;
         this.apiVersion = apiVersion;
+        this.sslContextFactory = sslContextFactory;
     }
 
     @Override
@@ -75,5 +80,10 @@ public class OAuth2BayeuxParameters implements BayeuxParameters {
     @Override
     public TimeUnit keepAliveUnit() {
         return TimeUnit.MILLISECONDS;
+    }
+
+    @Override
+    public SslContextFactory sslContextFactory() {
+        return sslContextFactory;
     }
 }


### PR DESCRIPTION
# Description

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8677

This PR adds the support for configuring mTLS in the Salesforce listener via the `secureSocket` configuration. This should allow users to configure a client key store and a trust store which establishes mutually authenticated TLS connections

Here the plan is to reuse the `http:ClientSecureSocket` type to set the configs to support mutual TLS.

```ballerina
# Common configuration for Salesforce listeners.
public type CommonListenerConfig record {|
    . . . //
    # Configurations relates to mTLS authentication. When provided, the listener presents a client certificate to the
    # Salesforce Streaming API endpoint during the TLS handshake.
    http:ClientSecureSocket secureSocket?;
|};
```

**Sample Salesforce Listener**

```ballerina
listener salesforce:Listener authListener = check new ({
    auth: {
        clientId,
        clientSecret,
        refreshToken,
        refreshUrl
    },
    secureSocket: {
        key: {
            path: "path/to/keystore.p12",
            password: "password"
        },
        cert: {
            path: "path/to/trustore.jks",
            password: "password"
        }
    },
    baseUrl,
    apiVersion: "59.0"
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds mutual TLS (mTLS) support to the Ballerina Salesforce listener so it can present client certificates when connecting to Salesforce endpoints that require mutual TLS, while preserving existing OAuth-based flows. Also improves private key loading to support additional key algorithms used with client keys.

## Changes

- Ballerina layer
  - Adds an optional http:ClientSecureSocket secureSocket? field to CommonListenerConfig.
  - Adds a secureSocket field to the Listener implementation, initializes it from the listener config, and propagates it through listener initialization paths.
  - Updates initListener and initListenerWithOAuth2 signatures to accept the secureSocket parameter and forwards it to native initialization helpers.

- Native Java implementation
  - Adds constants and parsing logic in ListenerUtil to read keystore/truststore and certificate/key settings from the secureSocket config.
  - Implements builders to construct an SslContextFactory (including PEM-based keystore/truststore support) and attaches the resulting SSL context to listener native data.
  - Adds helpers to build KeyStores and load private keys (updated to support additional key algorithms).
  - Extends listener startup/init flows to accept and propagate the SSL context into login and Bayeux parameter construction.
  - Adds LoginHelper overloads that accept an SslContextFactory and thread it through authentication flows.
  - Updates OAuth2BayeuxParameters to accept and expose a Supplier<SslContextFactory>.
  - Introduces BasicBayeuxParameters to represent Bayeux parameters with optional SSL context support.
  - Adds SpotBugs exclusions for the new classes/fields.

## Impact

Enables configuring client key and certificate material (keystore/truststore or PEM cert/key) for the listener so it can establish mutually authenticated TLS connections with Salesforce Streaming API endpoints, expanding supported deployment scenarios without altering existing OAuth behavior. The private key loading enhancements increase compatibility with different key formats and algorithms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->