### PR TITLE
Add HTTP proxy support for Salesforce Listener

### DIFF
--- a/ballerina/data_types.bal
+++ b/ballerina/data_types.bal
@@ -50,6 +50,36 @@ public type RestBasedListenerConfig record {|
     *CommonListenerConfig;
 |};
 
+# The transport protocol used to connect to the proxy server.
+public enum ProxyScheme {
+    # Unencrypted HTTP proxy connection
+    HTTP = "http",
+    # Encrypted HTTPS proxy connection
+    HTTPS = "https"
+}
+
+# Authentication credentials for proxy server access.
+public type ProxyAuthConfig record {|
+    # The username for authenticating with the proxy server
+    string username;
+    # The password for authenticating with the proxy server
+    string password;
+|};
+
+# Proxy server configuration for routing Salesforce listener traffic.
+public type ProxyConfig record {|
+    # The transport protocol used to connect to the proxy server.
+    # Defaults to `HTTP` which covers most corporate proxy setups
+    ProxyScheme scheme = HTTP;
+    # The hostname or IP address of the proxy server
+    string host;
+    # The port number on which the proxy server is listening
+    int port;
+    # Authentication credentials for the proxy server.
+    # If not provided, an unauthenticated proxy connection is assumed
+    ProxyAuthConfig auth?;
+|};
+
 # Common configuration for Salesforce listeners.
 public type CommonListenerConfig record {|
     # The replay ID to change the point in time when events are read
@@ -62,6 +92,8 @@ public type CommonListenerConfig record {|
     decimal keepAliveInterval = 120;
     # The Salesforce API version to use for Streaming API
     string apiVersion = "43.0";
+    # Proxy server configuration
+    ProxyConfig proxyConfig?;
 |};
 
 # The replay options representing the point in time when events are read.

--- a/ballerina/listener.bal
+++ b/ballerina/listener.bal
@@ -55,20 +55,21 @@ public isolated class Listener {
         }
         check utils:validateApiVersion(listenerConfig.apiVersion);
         self.apiVersion = listenerConfig.apiVersion;
+        ProxyConfig? proxyConfig = listenerConfig?.proxyConfig;
         if listenerConfig is RestBasedListenerConfig {
             self.username = "";
             self.password = "";
             self.isOAuth2 = true;
             self.oauth2Config = listenerConfig.auth.cloneReadOnly();
             initListenerWithOAuth2(self, self.replayFrom, listenerConfig.baseUrl,
-                    connectionTimeout, readTimeout, keepAliveInterval, self.apiVersion);
+                    connectionTimeout, readTimeout, keepAliveInterval, self.apiVersion, proxyConfig);
         } else {
             self.username = listenerConfig.auth.username;
             self.password = listenerConfig.auth.password;
             self.isOAuth2 = false;
             self.oauth2Config = ();
             initListener(self, self.replayFrom, listenerConfig.isSandBox,
-                    connectionTimeout, readTimeout, keepAliveInterval, self.apiVersion);
+                    connectionTimeout, readTimeout, keepAliveInterval, self.apiVersion, proxyConfig);
         }
     }
 
@@ -142,24 +143,26 @@ public isolated class Listener {
 }
 
 isolated function initListener(Listener instance, int replayFrom, boolean isSandBox,
-        decimal connectionTimeout, decimal readTimeout, decimal keepAliveInterval, string apiVersion) =
+        decimal connectionTimeout, decimal readTimeout, decimal keepAliveInterval, string apiVersion,
+        ProxyConfig? proxyConfig) =
 @java:Method {
     'class: "io.ballerinax.salesforce.ListenerUtil",
     paramTypes: ["io.ballerina.runtime.api.values.BObject", "int", "boolean",
         "io.ballerina.runtime.api.values.BDecimal", "io.ballerina.runtime.api.values.BDecimal",
-        "io.ballerina.runtime.api.values.BDecimal", "io.ballerina.runtime.api.values.BString"]
+        "io.ballerina.runtime.api.values.BDecimal", "io.ballerina.runtime.api.values.BString",
+        "java.lang.Object"]
 } external;
 
 isolated function initListenerWithOAuth2(Listener instance, int replayFrom, string baseUrl,
         decimal connectionTimeout, decimal readTimeout, decimal keepAliveInterval,
-        string apiVersion) =
+        string apiVersion, ProxyConfig? proxyConfig) =
 @java:Method {
     name: "initListener",
     'class: "io.ballerinax.salesforce.ListenerUtil",
     paramTypes: ["io.ballerina.runtime.api.values.BObject", "int",
         "io.ballerina.runtime.api.values.BString", "io.ballerina.runtime.api.values.BDecimal",
         "io.ballerina.runtime.api.values.BDecimal", "io.ballerina.runtime.api.values.BDecimal",
-        "io.ballerina.runtime.api.values.BString"]
+        "io.ballerina.runtime.api.values.BString", "java.lang.Object"]
 } external;
 
 isolated function attachService(Listener instance, Service s, string? channelName) returns error? =

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ This file contains all the notable changes done to the Ballerina Salesforce pack
 
 ### Added
 
+- [[#8744] Add HTTP proxy support for Salesforce Listener](https://github.com/ballerina-platform/ballerina-library/issues/8744)
+
+## [8.4.0] - 2026-03-13
+
+### Added
+
 - [[#8674] Add support for platform events in Salesforce listener](https://github.com/ballerina-platform/ballerina-library/issues/8674)
 
 ## [8.3.0] - 2026-02-18

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=8.4.2-SNAPSHOT
+version=8.5.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.0.18

--- a/native/src/main/java/io/ballerinax/salesforce/EmpConnector.java
+++ b/native/src/main/java/io/ballerinax/salesforce/EmpConnector.java
@@ -31,12 +31,15 @@ import org.cometd.bayeux.Message;
 import org.cometd.bayeux.client.ClientSessionChannel;
 import org.cometd.client.BayeuxClient;
 import org.cometd.client.http.jetty.JettyHttpClientTransport;
+import org.eclipse.jetty.client.Authentication;
+import org.eclipse.jetty.client.BasicAuthentication;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.ConnectException;
+import java.net.URI;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -205,6 +208,24 @@ public class EmpConnector {
      */
     public void setBearerTokenProvider(Function<Boolean, String> bearerTokenProvider) {
         this.bearerTokenProvider = bearerTokenProvider;
+    }
+
+    /**
+     * Configure basic authentication for a proxy server.
+     *
+     * @param proxyHost     the proxy host
+     * @param proxyPort     the proxy port
+     * @param proxyUsername the proxy username
+     * @param proxyPassword the proxy password
+     * @param secure        whether the proxy uses HTTPS ({@code true}) or HTTP ({@code false})
+     */
+    public void setProxyAuthentication(String proxyHost, int proxyPort,
+            String proxyUsername, String proxyPassword, boolean secure) {
+        String scheme = secure ? "https" : "http";
+        URI proxyUri = URI.create(String.format("%s://%s:%d", scheme, proxyHost, proxyPort));
+        httpClient.getAuthenticationStore().addAuthentication(
+                new BasicAuthentication(proxyUri, Authentication.ANY_REALM,
+                        proxyUsername, proxyPassword));
     }
 
     /**

--- a/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
+++ b/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
@@ -29,9 +29,13 @@ import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
+import org.eclipse.jetty.client.HttpProxy;
+import org.eclipse.jetty.client.Origin;
+import org.eclipse.jetty.client.ProxyConfiguration;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,13 +62,14 @@ public class ListenerUtil {
     public static final String API_VERSION = "apiVersion";
     public static final String GET_OAUTH2_TOKEN_METHOD = "getOAuth2Token";
     public static final String SUBSCRIPTIONS = "subscriptions";
+    public static final String PROXY_CONFIG = "proxyConfig";
     private static final String CONNECTOR = "connector";
     private static final List<String> CDC_METHODS = List.of(
             Constants.ON_CREATE, Constants.ON_UPDATE, Constants.ON_DELETE, Constants.ON_RESTORE);
 
     private static void extractBaseConfigs(BObject listener, int replayFrom,
             BDecimal connectionTimeout, BDecimal readTimeout, BDecimal keepAliveInterval,
-            BString apiVersion) {
+            BString apiVersion, Object proxyConfig) {
         listener.addNativeData(CONSUMER_SERVICES, new ArrayList<BObject>());
         listener.addNativeData(DISPATCHERS, new HashMap<BObject, DispatcherService>());
         listener.addNativeData(SUBSCRIPTIONS, new HashMap<BObject, TopicSubscription>());
@@ -78,18 +83,25 @@ public class ListenerUtil {
         listener.addNativeData(KEEP_ALIVE_INTERVAL, keepAliveIntervalMs);
         listener.addNativeData(CONNECTION_TIMEOUT + "_display",
             connectionTimeout.value().stripTrailingZeros().toPlainString());
+        if (proxyConfig != null) {
+            listener.addNativeData(PROXY_CONFIG, ProxyConfig.fromBMap(proxyConfig));
+        }
     }
 
     public static void initListener(BObject listener, int replayFrom, boolean isSandBox,
-            BDecimal connectionTimeout, BDecimal readTimeout, BDecimal keepAliveInterval, BString apiVersion) {
-        extractBaseConfigs(listener, replayFrom, connectionTimeout, readTimeout, keepAliveInterval, apiVersion);
+            BDecimal connectionTimeout, BDecimal readTimeout, BDecimal keepAliveInterval,
+            BString apiVersion, Object proxyConfig) {
+        extractBaseConfigs(listener, replayFrom, connectionTimeout, readTimeout, keepAliveInterval,
+                apiVersion, proxyConfig);
         listener.addNativeData(IS_OAUTH2, false);
         listener.addNativeData(IS_SAND_BOX, isSandBox);
     }
 
     public static void initListener(BObject listener, int replayFrom, BString baseUrl,
-            BDecimal connectionTimeout, BDecimal readTimeout, BDecimal keepAliveInterval, BString apiVersion) {
-        extractBaseConfigs(listener, replayFrom, connectionTimeout, readTimeout, keepAliveInterval, apiVersion);
+            BDecimal connectionTimeout, BDecimal readTimeout, BDecimal keepAliveInterval,
+            BString apiVersion, Object proxyConfig) {
+        extractBaseConfigs(listener, replayFrom, connectionTimeout, readTimeout, keepAliveInterval,
+                apiVersion, proxyConfig);
         listener.addNativeData(IS_OAUTH2, true);
         listener.addNativeData(BASE_URL, baseUrl.getValue());
     }
@@ -128,6 +140,7 @@ public class ListenerUtil {
         long readTimeoutMs = (Long) listener.getNativeData(READ_TIMEOUT);
         long keepAliveIntervalMs = (Long) listener.getNativeData(KEEP_ALIVE_INTERVAL);
         String apiVersion = (String) listener.getNativeData(API_VERSION);
+        List<ProxyConfiguration.Proxy> proxies = buildProxies(listener);
 
         BearerTokenProvider tokenProvider = new BearerTokenProvider(() -> {
             try {
@@ -140,7 +153,7 @@ public class ListenerUtil {
         BayeuxParameters params;
         try {
             BayeuxParameters loginParams = tokenProvider.login();
-            params = new TimeoutBayeuxParameters(loginParams, readTimeoutMs, keepAliveIntervalMs);
+            params = new TimeoutBayeuxParameters(loginParams, readTimeoutMs, keepAliveIntervalMs, proxies);
         } catch (Exception e) {
             throw sfdcError(e.getMessage(), e.getCause());
         }
@@ -153,10 +166,11 @@ public class ListenerUtil {
         long readTimeoutMs = (Long) listener.getNativeData(READ_TIMEOUT);
         long keepAliveIntervalMs = (Long) listener.getNativeData(KEEP_ALIVE_INTERVAL);
         String apiVersion = (String) listener.getNativeData(API_VERSION);
+        List<ProxyConfiguration.Proxy> proxies = buildProxies(listener);
 
         BearerTokenProvider tokenProvider = new BearerTokenProvider(() ->
             new OAuth2BayeuxParameters(() -> getOAuth2Token(env, listener), baseUrl,
-                readTimeoutMs, keepAliveIntervalMs, apiVersion));
+                readTimeoutMs, keepAliveIntervalMs, apiVersion, proxies));
 
         BayeuxParameters params;
         try {
@@ -168,12 +182,33 @@ public class ListenerUtil {
         return startConnector(params, tokenProvider, listener);
     }
 
+    static ProxyConfig getProxyConfig(BObject listener) {
+        return (ProxyConfig) listener.getNativeData(PROXY_CONFIG);
+    }
+
+    private static List<ProxyConfiguration.Proxy> buildProxies(BObject listener) {
+        ProxyConfig proxy = getProxyConfig(listener);
+        if (proxy == null) {
+            return Collections.emptyList();
+        }
+        return Collections.singletonList(
+                new HttpProxy(new Origin.Address(proxy.host(), proxy.port()), proxy.isSecure(), null));
+    }
+
     private static Object startConnector(BayeuxParameters params, BearerTokenProvider tokenProvider,
             BObject listener) {
         long connectionTimeoutMs = (Long) listener.getNativeData(CONNECTION_TIMEOUT);
         String connectionTimeoutDisplay = (String) listener.getNativeData(CONNECTION_TIMEOUT + "_display");
 
         EmpConnector connector = new EmpConnector(params);
+        // The proxy host/port is already registered in the BayeuxParameters via buildProxies(),
+        // so unauthenticated proxies work without any extra step.
+        // setProxyAuthentication is only needed when credentials are provided.
+        ProxyConfig proxy = getProxyConfig(listener);
+        if (proxy != null && proxy.hasCredentials()) {
+            connector.setProxyAuthentication(proxy.host(), proxy.port(),
+                    proxy.auth().username(), proxy.auth().password(), proxy.isSecure());
+        }
         connector.setBearerTokenProvider(tokenProvider);
         try {
             connector.start().get(connectionTimeoutMs, TimeUnit.MILLISECONDS);

--- a/native/src/main/java/io/ballerinax/salesforce/LoginHelper.java
+++ b/native/src/main/java/io/ballerinax/salesforce/LoginHelper.java
@@ -24,9 +24,14 @@
 package io.ballerinax.salesforce;
 
 import io.ballerina.runtime.api.values.BObject;
+import org.eclipse.jetty.client.Authentication;
+import org.eclipse.jetty.client.BasicAuthentication;
 import org.eclipse.jetty.client.BytesRequestContent;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpProxy;
+import org.eclipse.jetty.client.Origin;
+import org.eclipse.jetty.client.ProxyConfiguration;
 import org.eclipse.jetty.client.Request;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
@@ -34,7 +39,11 @@ import org.xml.sax.helpers.DefaultHandler;
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.ConnectException;
+import java.net.URI;
 import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -114,14 +123,55 @@ public class LoginHelper {
     private static final String SERVICES_SOAP_PARTNER_ENDPOINT_PREFIX = "/services/Soap/u/";
     private static final String SERVICES_SOAP_PARTNER_ENDPOINT_SUFFIX = "/";
 
-    public static BayeuxParameters login(String username, String password, 
+    public static BayeuxParameters login(String username, String password,
         BObject listener, String apiVersion) throws Exception {
         boolean isSandBox = (Boolean) listener.getNativeData(IS_SAND_BOX);
         String endpoint = getLoginEndpoint(isSandBox);
-        return login(new URL(endpoint), username, password, apiVersion);
+        ProxyConfig proxy = ListenerUtil.getProxyConfig(listener);
+        List<ProxyConfiguration.Proxy> proxies;
+        BasicAuthentication proxyAuth;
+        if (proxy != null) {
+            proxies = Collections.singletonList(
+                    new HttpProxy(new Origin.Address(proxy.host(), proxy.port()), proxy.isSecure(), null));
+            if (proxy.hasCredentials()) {
+                URI proxyUri = URI.create(String.format("%s://%s:%d", proxy.scheme(), proxy.host(), proxy.port()));
+                proxyAuth = new BasicAuthentication(proxyUri, Authentication.ANY_REALM,
+                        proxy.auth().username(), proxy.auth().password());
+            } else {
+                proxyAuth = null;
+            }
+        } else {
+            proxies = Collections.emptyList();
+            proxyAuth = null;
+        }
+        BayeuxParameters params = new BayeuxParameters() {
+            @Override
+            public String bearerToken() {
+                throw new IllegalStateException("Have not authenticated");
+            }
+
+            @Override
+            public URL endpoint() {
+                throw new IllegalStateException("Have not established replay endpoint");
+            }
+
+            @Override
+            public String version() {
+                return apiVersion;
+            }
+
+            @Override
+            public Collection<? extends ProxyConfiguration.Proxy> proxies() {
+                return proxies;
+            }
+        };
+        if (proxyAuth != null) {
+            return login(new URL(endpoint), username, password, params, apiVersion, proxyAuth);
+        }
+        return login(new URL(endpoint), username, password, params, apiVersion);
     }
 
-    public static BayeuxParameters login(URL loginEndpoint, String username, 
+    public static BayeuxParameters login(URL loginEndpoint, String username,
             String password, String apiVersion) throws Exception {
         return login(loginEndpoint, username, password, new BayeuxParameters() {
             @Override
@@ -143,10 +193,19 @@ public class LoginHelper {
 
     public static BayeuxParameters login(URL loginEndpoint, String username, String password,
                                          BayeuxParameters parameters, String apiVersion) throws Exception {
+        return login(loginEndpoint, username, password, parameters, apiVersion, null);
+    }
+
+    private static BayeuxParameters login(URL loginEndpoint, String username, String password,
+            BayeuxParameters parameters, String apiVersion,
+            BasicAuthentication proxyAuth) throws Exception {
         HttpClient client = new HttpClient();
         client.setSslContextFactory(parameters.sslContextFactory());
         try {
             parameters.proxies().forEach(client.getProxyConfiguration()::addProxy);
+            if (proxyAuth != null) {
+                client.getAuthenticationStore().addAuthentication(proxyAuth);
+            }
             client.start();
             URL endpoint = new URL(loginEndpoint, getSoapUri(apiVersion));
             Request post = client.POST(endpoint.toURI());

--- a/native/src/main/java/io/ballerinax/salesforce/OAuth2BayeuxParameters.java
+++ b/native/src/main/java/io/ballerinax/salesforce/OAuth2BayeuxParameters.java
@@ -18,8 +18,13 @@
 
 package io.ballerinax.salesforce;
 
+import org.eclipse.jetty.client.ProxyConfiguration;
+
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -32,14 +37,22 @@ public class OAuth2BayeuxParameters implements BayeuxParameters {
     private final long readTimeoutMs;
     private final long keepAliveIntervalMs;
     private final String apiVersion;
+    private final List<ProxyConfiguration.Proxy> proxiesList;
 
     public OAuth2BayeuxParameters(Supplier<String> tokenSupplier, String baseUrl,
         long readTimeoutMs, long keepAliveIntervalMs, String apiVersion) {
+        this(tokenSupplier, baseUrl, readTimeoutMs, keepAliveIntervalMs, apiVersion, Collections.emptyList());
+    }
+
+    public OAuth2BayeuxParameters(Supplier<String> tokenSupplier, String baseUrl,
+        long readTimeoutMs, long keepAliveIntervalMs, String apiVersion,
+        List<ProxyConfiguration.Proxy> proxies) {
         this.tokenSupplier = tokenSupplier;
         this.baseUrl = baseUrl;
         this.readTimeoutMs = readTimeoutMs;
         this.keepAliveIntervalMs = keepAliveIntervalMs;
         this.apiVersion = apiVersion;
+        this.proxiesList = List.copyOf(proxies);
     }
 
     @Override
@@ -75,5 +88,10 @@ public class OAuth2BayeuxParameters implements BayeuxParameters {
     @Override
     public TimeUnit keepAliveUnit() {
         return TimeUnit.MILLISECONDS;
+    }
+
+    @Override
+    public Collection<? extends ProxyConfiguration.Proxy> proxies() {
+        return Collections.unmodifiableList(proxiesList);
     }
 }

--- a/native/src/main/java/io/ballerinax/salesforce/ProxyAuthConfig.java
+++ b/native/src/main/java/io/ballerinax/salesforce/ProxyAuthConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerinax.salesforce;
+
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
+
+/**
+ * Representation of the ProxyAuthConfig record.
+ *
+ * @param username proxy username for basic authentication
+ * @param password proxy password for basic authentication
+ */
+record ProxyAuthConfig(String username, String password) {
+
+    static final String FIELD_USERNAME = "username";
+    static final String FIELD_PASSWORD = "password";
+
+    @SuppressWarnings("unchecked")
+    static ProxyAuthConfig fromBMap(Object obj) {
+        BMap<BString, Object> map = (BMap<BString, Object>) obj;
+        return new ProxyAuthConfig(
+                ((BString) map.get(StringUtils.fromString(FIELD_USERNAME))).getValue(),
+                ((BString) map.get(StringUtils.fromString(FIELD_PASSWORD))).getValue()
+        );
+    }
+}

--- a/native/src/main/java/io/ballerinax/salesforce/ProxyConfig.java
+++ b/native/src/main/java/io/ballerinax/salesforce/ProxyConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerinax.salesforce;
+
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
+
+/**
+ * Representation of the ProxyConfig record.
+ *
+ * @param scheme the transport protocol used to connect to the proxy server ({@code "http"} or {@code "https"})
+ * @param host   proxy server hostname
+ * @param port   proxy server port
+ * @param auth   proxy authentication credentials, or {@code null} if the proxy requires no authentication
+ */
+record ProxyConfig(String scheme, String host, int port, ProxyAuthConfig auth) {
+
+    static final String FIELD_SCHEME = "scheme";
+    static final String FIELD_HOST = "host";
+    static final String FIELD_PORT = "port";
+    static final String FIELD_AUTH = "auth";
+
+    boolean hasCredentials() {
+        return auth != null;
+    }
+
+    boolean isSecure() {
+        return "https".equals(scheme);
+    }
+
+    @SuppressWarnings("unchecked")
+    static ProxyConfig fromBMap(Object obj) {
+        BMap<BString, Object> map = (BMap<BString, Object>) obj;
+        Object authObj = map.get(StringUtils.fromString(FIELD_AUTH));
+        return new ProxyConfig(
+                ((BString) map.get(StringUtils.fromString(FIELD_SCHEME))).getValue(),
+                ((BString) map.get(StringUtils.fromString(FIELD_HOST))).getValue(),
+                ((Long) map.get(StringUtils.fromString(FIELD_PORT))).intValue(),
+                authObj != null ? ProxyAuthConfig.fromBMap(authObj) : null
+        );
+    }
+}

--- a/native/src/main/java/io/ballerinax/salesforce/TimeoutBayeuxParameters.java
+++ b/native/src/main/java/io/ballerinax/salesforce/TimeoutBayeuxParameters.java
@@ -18,19 +18,31 @@
 
 package io.ballerinax.salesforce;
 
+import org.eclipse.jetty.client.ProxyConfiguration;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A delegating BayeuxParameters implementation that overrides timeout and keep-alive settings.
+ * A delegating BayeuxParameters implementation that overrides timeout, keep-alive, and proxy settings.
  */
 public class TimeoutBayeuxParameters extends DelegatingBayeuxParameters {
     private final long readTimeoutMs;
     private final long keepAliveIntervalMs;
+    private final List<ProxyConfiguration.Proxy> proxiesList;
 
     public TimeoutBayeuxParameters(BayeuxParameters parameters, long readTimeoutMs, long keepAliveIntervalMs) {
+        this(parameters, readTimeoutMs, keepAliveIntervalMs, Collections.emptyList());
+    }
+
+    public TimeoutBayeuxParameters(BayeuxParameters parameters, long readTimeoutMs, long keepAliveIntervalMs,
+            List<ProxyConfiguration.Proxy> proxies) {
         super(parameters);
         this.readTimeoutMs = readTimeoutMs;
         this.keepAliveIntervalMs = keepAliveIntervalMs;
+        this.proxiesList = List.copyOf(proxies);
     }
 
     @Override
@@ -46,5 +58,10 @@ public class TimeoutBayeuxParameters extends DelegatingBayeuxParameters {
     @Override
     public TimeUnit keepAliveUnit() {
         return TimeUnit.MILLISECONDS;
+    }
+
+    @Override
+    public Collection<? extends ProxyConfiguration.Proxy> proxies() {
+        return Collections.unmodifiableList(proxiesList);
     }
 }


### PR DESCRIPTION
# Description
$Subject

It fixes: https://github.com/ballerina-platform/ballerina-library/issues/8744

Related Pull Requests (remove if not relevant)
- Pull request 1
- Pull request 2

One line release note: 
- One line describing the feature/improvement/fix made by this PR 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Ballerina Version:
* Operating System:
* Java SDK: 

# Checklist:

### Security checks
 - [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds configurable HTTP proxy support for the Salesforce Listener so deployments requiring outbound connections can route listener networking and OAuth2 login flows through an HTTP/HTTPS proxy, including optional proxy credentials.

## Changes

Ballerina layer
- New public types: ProxyScheme (HTTP/HTTPS), ProxyAuthConfig (username, password), and ProxyConfig (scheme, host, port, optional auth).
- CommonListenerConfig extended with an optional proxyConfig field.
- Listener.init() and isolated Java interop signatures updated to extract and forward proxyConfig to the native layer.

Java native layer
- New records ProxyAuthConfig and ProxyConfig with factory methods to read Ballerina maps and helpers (hasCredentials(), isSecure()).
- EmpConnector.setProxyAuthentication(...) added to configure proxy basic authentication with Jetty HttpClient when credentials are provided.
- ListenerUtil extended to accept/store proxyConfig, build Jetty ProxyConfiguration.Proxy entries, pass proxies into connector initialization and Bayeux parameter objects, and apply proxy authentication conditionally.
- LoginHelper updated to derive and register proxy settings with its internal HttpClient and to use proxy-aware login flows when credentials are present.
- OAuth2BayeuxParameters and TimeoutBayeuxParameters extended to accept and expose proxy lists via proxies().

Metadata
- Changelog updated to note addition of HTTP proxy support.
- Project version updated from 8.4.2-SNAPSHOT to 8.5.0-SNAPSHOT.

## Impact

Listeners can be configured with proxy host/port and optional credentials; proxy settings are propagated through Bayeux parameters and OAuth2 login so outbound HTTP requests from the listener operate correctly in environments that require proxying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->