### PR TITLE
Add proxy support for `RefreshTokenGrant` token refresh in Salesforce Listener 

### DIFF
--- a/ballerina/listener.bal
+++ b/ballerina/listener.bal
@@ -102,7 +102,8 @@ public isolated class Listener {
                     rtConfig.refreshToken, rtConfig.refreshUrl,
                     sessionTimeoutSeconds,
                     TOKEN_REFRESH_BUFFER_SECONDS,
-                    listenerConfig.tokenStore
+                    listenerConfig.tokenStore,
+                    proxyConfig
                 );
             } else {
                 self.tokenManager = ();

--- a/ballerina/token_manager.bal
+++ b/ballerina/token_manager.bal
@@ -98,12 +98,15 @@ isolated class TokenManager {
     #               Defaults to a fresh `InMemoryTokenStore` (single-replica, in-process).
     #               Pass a distributed implementation (e.g. Redis-backed) to coordinate
     #               token refresh across multiple pods and prevent Token Replay Attacks.
+    # + proxyConfig - Optional proxy server configuration. When set, all token refresh HTTP
+    #        calls are routed through the specified proxy.
     # + return - An error if the HTTP client cannot be created
     isolated function init(string clientId, string clientSecret,
             string refreshToken, string tokenUrl,
             int sessionTimeoutSeconds = 900,
             int refreshBufferSeconds = 60,
-            TokenStore tokenStore = new InMemoryTokenStore()) returns error? {
+            TokenStore tokenStore = new InMemoryTokenStore(),
+            ProxyConfig? proxyConfig = ()) returns error? {
         self.clientId = clientId;
         self.clientSecret = clientSecret;
         self.refreshToken = refreshToken;
@@ -121,7 +124,17 @@ isolated class TokenManager {
         }
         self.tokenStore = tokenStore;
         self.storeKey = "sf_token:" + fingerprintToken(clientId);
-        self.tokenClient = check new (tokenUrl);
+        if proxyConfig is ProxyConfig {
+            http:ProxyConfig httpProxy = {
+                host: proxyConfig.host,
+                port: proxyConfig.port,
+                userName: proxyConfig.auth?.username ?: "",
+                password: proxyConfig.auth?.password ?: ""
+            };
+            self.tokenClient = check new (tokenUrl, {proxy: httpProxy});
+        } else {
+            self.tokenClient = check new (tokenUrl);
+        }
     }
 
     # Returns a valid access token, refreshing proactively if expired or about to expire.


### PR DESCRIPTION
# Description
$Subject

One line release note: 
- One line describing the feature/improvement/fix made by this PR 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Ballerina Version:
* Operating System:
* Java SDK: 

# Checklist:

### Security checks
 - [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request adds proxy support to the Salesforce listener's token refresh mechanism. The changes enable the `RefreshTokenGrant` token refresh flow to route HTTP requests through a configured proxy.

### Changes Made

**listener.bal:**
- Updated `Listener.init` to pass the `proxyConfig` parameter to the `TokenManager` when constructing it in the OAuth2 `RefreshTokenGrantConfig` branch

**token_manager.bal:**
- Extended `TokenManager.init` to accept an optional `ProxyConfig? proxyConfig` parameter
- Implemented conditional proxy configuration logic that creates an `http:ProxyConfig` from the provided proxy settings when specified
- Modified the token HTTP client instantiation to use proxy routing when proxy configuration is supplied

### Impact

These changes allow users to configure a proxy for the Salesforce listener's token refresh operations, expanding the listener's flexibility for deployments that require proxy-based network access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->