### PR TITLE
Fix Listener ignoring user-provided replayFrom integer

### DIFF
--- a/ballerina/listener.bal
+++ b/ballerina/listener.bal
@@ -49,8 +49,10 @@ public isolated class Listener {
     public isolated function init(ListenerConfig listenerConfig) returns error? {
         if listenerConfig.replayFrom is REPLAY_FROM_TIP {
             self.replayFrom = -1;
-        } else {
+        } else if listenerConfig.replayFrom is REPLAY_FROM_EARLIEST {
             self.replayFrom = -2;
+        } else {
+            self.replayFrom = <int>listenerConfig.replayFrom;
         }
         decimal connectionTimeout = listenerConfig.connectionTimeout;
         if connectionTimeout <= 0d {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=8.6.1-SNAPSHOT
+version=8.6.2-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.0.18


### PR DESCRIPTION
# Description

Fix `replayFrom` integer value being ignored in `Listener`, which caused all events to replay from the earliest retention window instead of the specified replay ID 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Ballerina Version:
* Operating System:
* Java SDK: 

# Checklist:

### Security checks
 - [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an issue in the `Listener` initialization where user-provided `replayFrom` integer values were being ignored, causing event consumption to always start from the earliest retention window rather than from the specified replay ID.

## Changes

**listener.bal**: Improved input handling in `Listener.init` by explicitly distinguishing between three `replayFrom` cases:
- `REPLAY_FROM_TIP` maps to `-1`
- `REPLAY_FROM_EARLIEST` maps to `-2`  
- User-provided integer values are now explicitly cast to `int` and assigned to `self.replayFrom`

This ensures that custom replay configurations are properly respected during listener initialization.

**Version updates**: Module and build versions incremented from `8.6.0`/`8.6.1-SNAPSHOT` to `8.6.2`/`8.6.2-SNAPSHOT` respectively across configuration files (`Ballerina.toml`, `gradle.properties`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->