### PR TITLE
Add onError Callback for PlatformEventsService and CdcService 

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.12.0"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -106,7 +106,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -280,7 +280,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -327,7 +327,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},
@@ -412,7 +412,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "redis"
-version = "3.2.1"
+version = "3.2.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "crypto"},

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -9,7 +9,8 @@ The Salesforce connector supports various Salesforce APIs including REST, SOAP, 
 - Support for REST, SOAP, APEX REST, BULK, and BULK V2 APIs
 - Perform CRUD operations on sObjects and metadata
 - Execute complex queries and searches
-- Listen to real-time change events via CometD
+- Listen to real-time Change Data Capture events and Platform Events via CometD
+- Handle listener errors gracefully with an optional `onError` callback
 - Efficient management of large datasets using Bulk APIs
 
 ## Setup guide
@@ -146,7 +147,42 @@ service "/data/ChangeEvents" on eventListener {
 }
 ```
 
-3. Integrate custom SObject types
+3. Optionally, add an `onError` remote function to handle errors from `onMessage`/`onCreate`/`onUpdate`/`onDelete`/`onRestore` or from failed CometD subscriptions:
+
+```ballerina
+import ballerina/io;
+import ballerina/log;
+import ballerinax/salesforce;
+
+salesforce:ListenerConfig listenerConfig = {
+    auth: {
+        clientId: "<clientId>",
+        clientSecret: "<clientSecret>",
+        refreshToken: "<refreshToken>",
+        refreshUrl: "https://login.salesforce.com/services/oauth2/token"
+    },
+    baseUrl: "https://<instance>.salesforce.com"
+};
+listener salesforce:Listener eventListener = new (listenerConfig);
+
+service "/event/MyEvent__e" on eventListener {
+    remote function onMessage(salesforce:PlatformEventsMessage message) returns error? {
+        io:println("Platform event received: ", message.payload);
+    }
+
+    remote function onError(error err) returns error? {
+        log:printError("Listener error", 'error = err);
+    }
+}
+```
+
+The `onError` callback is invoked in two situations:
+- When `onMessage` (or a CDC handler) returns an `error`
+- When the CometD subscription itself fails (e.g., stale replay ID)
+
+If `onError` is not defined and a subscription failure occurs, `start()` returns the error directly.
+
+4. Integrate custom SObject types
 
 To seamlessly integrate custom SObject types into your Ballerina project, you have the option to either generate a package using the Ballerina Open API tool or utilize the `ballerinax/salesforce.types` module. Follow the steps given [here](https://github.com/ballerina-platform/module-ballerinax-salesforce/blob/master/ballerina/modules/types/Module.md) based on your preferred approach.
 

--- a/ballerina/listener.bal
+++ b/ballerina/listener.bal
@@ -412,6 +412,7 @@ isolated class TokenRefreshJob {
         error? startErr = startListenerWithOAuth2(self.listenerInstance);
         if startErr is error {
             log:printError("Proactive token refresh failed", 'error = startErr);
+            notifyServicesOnError(self.listenerInstance, startErr.message());
             // startListenerWithOAuth2() → getOAuth2Token() → invalid_grant sets the flag.
             // We check it immediately after the call to prevent even ONE more scheduler tick.
             if self.listenerInstance.isTokenRefreshPermanentlyFailed() {
@@ -496,6 +497,11 @@ isolated function detachService(Listener instance, Service s) returns error? =
 } external;
 
 isolated function stopListener(Listener instance) returns error? =
+@java:Method {
+    'class: "io.ballerinax.salesforce.ListenerUtil"
+} external;
+
+isolated function notifyServicesOnError(Listener instance, string message) =
 @java:Method {
     'class: "io.ballerinax.salesforce.ListenerUtil"
 } external;

--- a/ballerina/service_types.bal
+++ b/ballerina/service_types.bal
@@ -43,6 +43,8 @@ public type CdcService service object {
     # + payload - The information about the triggered event
     # + return - `()` on success else an `error`
     remote function onRestore(EventData payload) returns error?;
+
+    // remote function onError(error err) returns error?;
 };
 
 # Triggers when a new Platform Event is received from Salesforce channels.
@@ -53,4 +55,6 @@ public type PlatformEventsService service object {
     # + message - The Platform Events message including all published fields and metadata
     # + return - `()` on success else an `error`
     remote function onMessage(PlatformEventsMessage message) returns error?;
+
+    // remote function onError(error err) returns error?;
 };

--- a/ballerina/tests/platform_event_listener_test.bal
+++ b/ballerina/tests/platform_event_listener_test.bal
@@ -20,6 +20,8 @@ import ballerina/test;
 
 configurable string platformEventApiName = os:getEnv("PLATFORM_EVENT_API_NAME");
 
+const int INVALID_REPLAY_ID = -100;
+
 isolated boolean isPlatformEventReceived = false;
 isolated boolean onErrorCalledForOnMessage = false;
 isolated string onErrorMessageForOnMessage = "";
@@ -280,7 +282,7 @@ function testOnErrorInvokedOnSubscriptionFailure() returns error? {
     Listener peListener = check new ({
         auth: {clientId, clientSecret, refreshToken, refreshUrl},
         baseUrl,
-        replayFrom: 1
+        replayFrom: INVALID_REPLAY_ID
     });
 
     Service peService = service object {
@@ -312,7 +314,7 @@ function testSubscriptionFailureReturnedWithoutOnError() returns error? {
     Listener peListener = check new ({
         auth: {clientId, clientSecret, refreshToken, refreshUrl},
         baseUrl,
-        replayFrom: 1
+        replayFrom: INVALID_REPLAY_ID
     });
 
     Service peService = service object {

--- a/ballerina/tests/platform_event_listener_test.bal
+++ b/ballerina/tests/platform_event_listener_test.bal
@@ -21,6 +21,9 @@ import ballerina/test;
 configurable string platformEventApiName = os:getEnv("PLATFORM_EVENT_API_NAME");
 
 isolated boolean isPlatformEventReceived = false;
+isolated boolean onErrorCalledForOnMessage = false;
+isolated string onErrorMessageForOnMessage = "";
+isolated boolean onErrorCalledForSubscription = false;
 
 @test:Config {
     groups: ["platform-events"]
@@ -218,4 +221,107 @@ function testListenerInitWithWhitespaceBaseUrl() returns error? {
         test:assertEquals(result.message(),
             "Salesforce base URL cannot be empty. Please verify and provide a valid URL");
     }
+}
+
+// Test: onError is invoked when onMessage returns an error
+@test:Config {
+    groups: ["platform-events"]
+}
+function testOnErrorInvokedWhenOnMessageFails() returns error? {
+    lock { onErrorCalledForOnMessage = false; }
+    lock { onErrorMessageForOnMessage = ""; }
+
+    Listener peListener = check new ({
+        auth: {clientId, clientSecret, refreshToken, refreshUrl},
+        baseUrl,
+        replayFrom: REPLAY_FROM_TIP
+    });
+
+    Service peService = service object {
+        remote function onMessage(PlatformEventsMessage message) returns error? {
+            return error("simulated-onMessage-failure");
+        }
+
+        remote function onError(error err) returns error? {
+            lock { onErrorCalledForOnMessage = true; }
+            lock { onErrorMessageForOnMessage = err.message(); }
+        }
+    };
+
+    check peListener.attach(peService, platformEventApiName);
+    check peListener.'start();
+    runtime:registerListener(peListener);
+
+    string eventSObjectName = platformEventApiName.startsWith("/event/")
+        ? platformEventApiName.substring("/event/".length())
+        : platformEventApiName;
+    CreationResponse _ = check sfdc->create(eventSObjectName, {});
+    runtime:sleep(10);
+
+    lock {
+        test:assertTrue(onErrorCalledForOnMessage,
+            "onError was not invoked when onMessage returned an error");
+    }
+    lock {
+        test:assertEquals(onErrorMessageForOnMessage, "simulated-onMessage-failure");
+    }
+    check peListener.gracefulStop();
+}
+
+// Test: subscription failure (stale replayId) invokes onError and returns error from start()
+@test:Config {
+    groups: ["platform-events"]
+}
+function testOnErrorInvokedOnSubscriptionFailure() returns error? {
+    lock {
+        onErrorCalledForSubscription = false;
+    }
+
+    Listener peListener = check new ({
+        auth: {clientId, clientSecret, refreshToken, refreshUrl},
+        baseUrl,
+        replayFrom: 1
+    });
+
+    Service peService = service object {
+        remote function onMessage(PlatformEventsMessage message) returns error? {}
+
+        remote function onError(error err) returns error? {
+            lock {
+                onErrorCalledForSubscription = true;
+            }
+        }
+    };
+
+    check peListener.attach(peService, platformEventApiName);
+    error? startResult = peListener.'start();
+
+    test:assertTrue(startResult is error,
+        "Expected start() to return an error on stale replayId");
+    lock {
+        test:assertTrue(onErrorCalledForSubscription,
+            "onError was not invoked on subscription failure");
+    }
+}
+
+// Test: subscription failure without onError returns error from start() without panicking
+@test:Config {
+    groups: ["platform-events"]
+}
+function testSubscriptionFailureReturnedWithoutOnError() returns error? {
+    Listener peListener = check new ({
+        auth: {clientId, clientSecret, refreshToken, refreshUrl},
+        baseUrl,
+        replayFrom: 1
+    });
+
+    Service peService = service object {
+        remote function onMessage(PlatformEventsMessage message) returns error? {}
+    };
+
+    check peListener.attach(peService, platformEventApiName);
+    error? startResult = peListener.'start();
+
+    test:assertTrue(startResult is error,
+        "Expected start() to return an error on stale replayId when no onError is defined");
 }

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -1,7 +1,7 @@
 # Specification: Ballerina Salesforce package
 _Authors_: @sahanHe \
 _Reviewers_: @daneshk, @Bhashinee \
-_Updated_: 2024/02/12 \
+_Updated_: 2026/06/04 \
 _Edition_: Swan Lake  
 
 ## Introduction
@@ -63,10 +63,17 @@ The conforming implementation of the specification is released and included in t
         41. [deleteJob](#deleteJob)
         42. [closeIngestJobAndWait](#closeIngestJobAndWait)
         43. [closeIngestJob](#closeIngestJob)
-3. [Bulk Client](#3-bulkclient)
-    1. [Client Configurations](#31-client-configurations)
-    2. [Initialization](#32-initialization)
-    3. [Bulk APIs](#33-bulkapis)
+3. [Listener](#3-listener)
+    1. [Listener Configurations](#31-listener-configurations)
+    2. [Initialization](#32-listener-initialization)
+    3. [Service Types](#33-service-types)
+        1. [CdcService](#331-cdcservice)
+        2. [PlatformEventsService](#332-platformeventsservice)
+    4. [Error Handling](#34-error-handling)
+4. [Bulk Client](#4-bulkclient)
+    1. [Client Configurations](#41-client-configurations)
+    2. [Initialization](#42-initialization)
+    3. [Bulk APIs](#43-bulkapis)
         1. [getJobInfo](#getJobInfoV1)
         2. [closeJob](#closeJobV1)
         3. [abortJob](#abortJobV1)
@@ -75,10 +82,10 @@ The conforming implementation of the specification is released and included in t
         6. [getAllBatches](#getAllBatchesV1)
         7. [getBatchRequest](#getBatchRequestV1)
         8. [getBatchRequest](#getBatchRequestV1)
-4. [Soap Client](#4-soapclient)
-    1. [Client Configurations](#41-client-configurations)
-    2. [Initialization](#42-initialization)
-    3. [Soap APIs](#43-soapapis)
+5. [Soap Client](#5-soapclient)
+    1. [Client Configurations](#51-client-configurations)
+    2. [Initialization](#52-initialization)
+    3. [Soap APIs](#53-soapapis)
         1. [convertLead](#convertLead)
 
 
@@ -700,11 +707,116 @@ Used to notify Salesforce servers that the upload of job data is complete.
 isolated remote function closeIngestJob(string bulkJobId) returns error|BulkJobCloseInfo
 ```
 
-## 3. [Bulk Client](#3-bulkclient)
+## 3. [Listener](#3-listener)
 
-`salesforce.bulk:Client` can be used to access the Salesforce Bulk API. 
+`salesforce:Listener` subscribes to Salesforce Streaming API channels over CometD to receive real-time Change Data Capture (CDC) events and Platform Events.
 
-### 3.1. [Client Configurations](#31-client-configurations)
+### 3.1. [Listener Configurations](#31-listener-configurations)
+
+The listener accepts either password-based (`SoapBasedListenerConfig`) or OAuth2-based (`RestBasedListenerConfig`) authentication:
+
+```ballerina
+# Salesforce listener configuration for password based authentication against the SOAP API endpoint.
+public type SoapBasedListenerConfig record {|
+    CredentialsConfig auth;
+    boolean isSandBox = false;
+    *CommonListenerConfig;
+|};
+
+# Salesforce listener configuration for OAuth2 based authentication.
+public type RestBasedListenerConfig record {|
+    OAuth2Config auth;
+    string baseUrl;
+    TokenStore tokenStore = new InMemoryTokenStore();
+    *CommonListenerConfig;
+|};
+
+# Common configuration for Salesforce listeners.
+public type CommonListenerConfig record {|
+    int|ReplayOptions replayFrom = REPLAY_FROM_TIP;
+    decimal connectionTimeout = 30;
+    decimal readTimeout = 120;
+    decimal keepAliveInterval = 30;
+    string apiVersion = "43.0";
+    ProxyConfig proxyConfig?;
+|};
+```
+
+### 3.2. [Initialization](#32-listener-initialization)
+
+A listener is created with a `ListenerConfig` and services are attached either declaratively or programmatically:
+
+```ballerina
+// Declarative (module-level)
+listener salesforce:Listener eventListener = new ({
+    auth: {username: "<username>", password: "<password><token>"}
+});
+
+// Programmatic
+salesforce:Listener eventListener = check new ({
+    auth: {clientId: "<id>", clientSecret: "<secret>",
+           refreshToken: "<token>", refreshUrl: "<url>"},
+    baseUrl: "https://<instance>.salesforce.com"
+});
+check eventListener.attach(myService, "/data/ChangeEvents");
+check eventListener.'start();
+```
+
+### 3.3. [Service Types](#33-service-types)
+
+#### 3.3.1. [CdcService](#331-cdcservice)
+
+Handles Change Data Capture events. Channel names follow the pattern `/data/<SObjectName>ChangeEvent` or `/data/ChangeEvents` for all objects.
+
+```ballerina
+public type CdcService service object {
+    remote function onCreate(EventData payload) returns error?;
+    remote function onUpdate(EventData payload) returns error?;
+    remote function onDelete(EventData payload) returns error?;
+    remote function onRestore(EventData payload) returns error?;
+    // remote function onError(error err) returns error?;
+};
+```
+
+#### 3.3.2. [PlatformEventsService](#332-platformeventsservice)
+
+Handles Platform Events. Channel names follow the pattern `/event/<EventName>__e`.
+
+```ballerina
+public type PlatformEventsService service object {
+    remote function onMessage(PlatformEventsMessage message) returns error?;
+    // remote function onError(error err) returns error?;
+};
+```
+
+### 3.4. [Error Handling](#34-error-handling)
+
+Both service types support an optional `onError` remote function for centralised error handling. It is invoked in two situations:
+
+1. **Handler error** — when `onMessage`, `onCreate`, `onUpdate`, `onDelete`, or `onRestore` returns an `error`.
+2. **Subscription failure** — when the CometD subscription itself fails (e.g., stale or invalid replay ID). In this case `onError` is called first and then `start()` returns the error.
+
+If `onError` is not defined:
+- Handler errors cause the listener to panic.
+- Subscription failures are returned directly from `start()`.
+
+```ballerina
+service "/event/OrderUpdate__e" on eventListener {
+    remote function onMessage(salesforce:PlatformEventsMessage message) returns error? {
+        // process the event; returning an error routes it to onError
+    }
+
+    remote function onError(error err) returns error? {
+        log:printError("Listener error", 'error = err);
+    }
+}
+```
+
+## 4. [Bulk Client](#4-bulkclient)
+
+`salesforce.bulk:Client` can be used to access the Salesforce Bulk API.
+
+### 4.1. [Client Configurations](#41-client-configurations)
 
 When initializing the client, following configurations can be provided,
 
@@ -718,7 +830,7 @@ public type ConnectionConfig record {|
 |};
 ```
 
-### 3.2. [Initialization](#32-initialization)
+### 4.2. [Initialization](#42-initialization)
 
 A client can be initialized by providing the Salesforce and optionally the other configurations in `ClientConfiguration`.
 
@@ -733,7 +845,7 @@ ConnectionConfig config = {
 Client salesforceClient = check new (config);
 ```
 
-### 3.3. [Bulk APIs](#33-bulkapis)
+### 4.3. [Bulk APIs](#43-bulkapis)
 
 #### [createJob](#createJobV1)
 
@@ -853,11 +965,11 @@ Used to get the request payload of a batch.
 isolated remote function getBatchResult(BulkJob bulkJob, string batchId) returns error|json|xml|string|Result[]
 ```
 
-## 4. [SOAP Client](#4-soapclient)
+## 5. [SOAP Client](#5-soapclient)
 
-`salesforce.soap:Client` can be used to access the Salesforce SOAP API. 
+`salesforce.soap:Client` can be used to access the Salesforce SOAP API.
 
-### 4.1. [Client Configurations](#41-client-configurations)
+### 5.1. [Client Configurations](#51-client-configurations)
 
 When initializing the client, following configurations can be provided,
 
@@ -871,7 +983,7 @@ public type ConnectionConfig record {|
 |};
 ```
 
-### 4.2. [Initialization](#42-initialization)
+### 5.2. [Initialization](#52-initialization)
 
 A client can be initialized by providing the Salesforce and optionally the other configurations in `ClientConfiguration`.
 
@@ -886,7 +998,7 @@ ConnectionConfig config = {
 Client salesforceClient = check new (config);
 ```
 
-### 4.3. [Soap APIs](#43-soapapis)
+### 5.3. [Soap APIs](#53-soapapis)
 
 #### [convertLead](#convertLead)
 

--- a/native/src/main/java/io/ballerinax/salesforce/Constants.java
+++ b/native/src/main/java/io/ballerinax/salesforce/Constants.java
@@ -50,6 +50,7 @@ public class Constants {
     public static final String ON_UPDATE = "onUpdate";
     public static final String ON_DELETE = "onDelete";
     public static final String ON_RESTORE = "onRestore";
+    public static final String ON_ERROR = "onError";
     public static final String UPDATE = "UPDATE";
     public static final String CREATE = "CREATE";
     public static final String DELETE = "DELETE";

--- a/native/src/main/java/io/ballerinax/salesforce/DispatcherService.java
+++ b/native/src/main/java/io/ballerinax/salesforce/DispatcherService.java
@@ -182,8 +182,9 @@ public class DispatcherService {
         BMap<BString, Object> returnMap = ValueCreator.createMapValue();
         if (map != null) {
             for (Object aKey : map.keySet().toArray()) {
+                Object value = map.get(aKey);
                 returnMap.put(StringUtils.fromString(aKey.toString()),
-                        StringUtils.fromString(map.get(aKey).toString()));
+                        value != null ? StringUtils.fromString(value.toString()) : null);
             }
         }
         return returnMap;

--- a/native/src/main/java/io/ballerinax/salesforce/DispatcherService.java
+++ b/native/src/main/java/io/ballerinax/salesforce/DispatcherService.java
@@ -132,6 +132,9 @@ public class DispatcherService {
     private void executeResourceOnEvent(BMap<BString, Object> eventRecord, String functionName) {
         Object result = executeResource(functionName, eventRecord);
         if (result instanceof BError bError) {
+            if (!methodNames.contains(ON_ERROR)) {
+                throw bError;
+            }
             BError onErrorResult = invokeOnError(bError);
             if (onErrorResult != null) {
                 throw onErrorResult;

--- a/native/src/main/java/io/ballerinax/salesforce/DispatcherService.java
+++ b/native/src/main/java/io/ballerinax/salesforce/DispatcherService.java
@@ -132,18 +132,22 @@ public class DispatcherService {
     private void executeResourceOnEvent(BMap<BString, Object> eventRecord, String functionName) {
         Object result = executeResource(functionName, eventRecord);
         if (result instanceof BError bError) {
-            invokeOnError(bError);
+            BError onErrorResult = invokeOnError(bError);
+            if (onErrorResult != null) {
+                throw onErrorResult;
+            }
         }
     }
 
-    public void invokeOnError(BError error) {
+    public BError invokeOnError(BError error) {
         if (!methodNames.contains(ON_ERROR)) {
-            throw error;
+            return null;
         }
         ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(service));
         boolean isIsolated = serviceType.isIsolated() && serviceType.isIsolated(ON_ERROR);
-        runtime.callMethod(service, ON_ERROR,
+        Object result = runtime.callMethod(service, ON_ERROR,
                 new StrandMetadata(isIsolated, ModuleUtils.getProperties(ON_ERROR)), error);
+        return result instanceof BError bError ? bError : null;
     }
 
     private Object executeResource(String functionName, BMap<BString, Object> eventRecord) {

--- a/native/src/main/java/io/ballerinax/salesforce/DispatcherService.java
+++ b/native/src/main/java/io/ballerinax/salesforce/DispatcherService.java
@@ -53,6 +53,7 @@ import static io.ballerinax.salesforce.Constants.EVENT_METADATA_RECORD;
 import static io.ballerinax.salesforce.Constants.EVENT_PAYLOAD;
 import static io.ballerinax.salesforce.Constants.ON_CREATE;
 import static io.ballerinax.salesforce.Constants.ON_DELETE;
+import static io.ballerinax.salesforce.Constants.ON_ERROR;
 import static io.ballerinax.salesforce.Constants.ON_RESTORE;
 import static io.ballerinax.salesforce.Constants.ON_UPDATE;
 import static io.ballerinax.salesforce.Constants.RECORD_IDS;
@@ -131,8 +132,18 @@ public class DispatcherService {
     private void executeResourceOnEvent(BMap<BString, Object> eventRecord, String functionName) {
         Object result = executeResource(functionName, eventRecord);
         if (result instanceof BError bError) {
-            throw bError;
+            invokeOnError(bError);
         }
+    }
+
+    public void invokeOnError(BError error) {
+        if (!methodNames.contains(ON_ERROR)) {
+            throw error;
+        }
+        ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(service));
+        boolean isIsolated = serviceType.isIsolated() && serviceType.isIsolated(ON_ERROR);
+        runtime.callMethod(service, ON_ERROR,
+                new StrandMetadata(isIsolated, ModuleUtils.getProperties(ON_ERROR)), error);
     }
 
     private Object executeResource(String functionName, BMap<BString, Object> eventRecord) {

--- a/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
+++ b/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
@@ -264,8 +264,8 @@ public class ListenerUtil {
             } catch (Exception e) {
                 connector.stop();
                 BError subscriptionError = sfdcError(e.getMessage(), e.getCause());
-                dispatcherService.invokeOnError(subscriptionError);
-                return subscriptionError;
+                BError onErrorResult = dispatcherService.invokeOnError(subscriptionError);
+                return onErrorResult != null ? onErrorResult : subscriptionError;
             }
         }
         return null;

--- a/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
+++ b/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
@@ -176,7 +176,9 @@ public class ListenerUtil {
         try {
             params = tokenProvider.login();
         } catch (Exception e) {
-            throw sfdcError(e.getMessage(), e.getCause());
+            BError loginError = sfdcError(e.getMessage(), e.getCause());
+            notifyAllDispatchersOnError(listener, loginError);
+            return loginError;
         }
 
         return startConnector(params, tokenProvider, listener);
@@ -245,7 +247,14 @@ public class ListenerUtil {
                         null);
             }
 
-            Consumer<Map<String, Object>> consumer = event -> injectEvent(dispatcherService, event);
+            Consumer<Map<String, Object>> consumer = event -> {
+                try {
+                    injectEvent(dispatcherService, event);
+                } catch (Exception e) {
+                    BError error = sfdcError(e.getMessage(), e.getCause());
+                    dispatcherService.invokeOnError(error);
+                }
+            };
 
             try {
                 TopicSubscription subscription = connector.subscribe(channelName, replayFrom, consumer)
@@ -253,10 +262,33 @@ public class ListenerUtil {
                 subscriptionMap.put(service, subscription);
             } catch (Exception e) {
                 connector.stop();
-                return sfdcError(e.getMessage(), e.getCause());
+                BError subscriptionError = sfdcError(e.getMessage(), e.getCause());
+                dispatcherService.invokeOnError(subscriptionError);
+                return subscriptionError;
             }
         }
         return null;
+    }
+
+    public static void notifyServicesOnError(BObject listener, BString message) {
+        notifyAllDispatchersOnError(listener, sfdcError(message.getValue(), null));
+    }
+
+    private static void notifyAllDispatchersOnError(BObject listener, BError error) {
+        @SuppressWarnings("unchecked")
+        ArrayList<BObject> services = (ArrayList<BObject>) listener.getNativeData(CONSUMER_SERVICES);
+        @SuppressWarnings("unchecked")
+        Map<BObject, DispatcherService> serviceDispatcherMap =
+                (Map<BObject, DispatcherService>) listener.getNativeData(DISPATCHERS);
+        if (services == null || serviceDispatcherMap == null) {
+            return;
+        }
+        for (BObject service : services) {
+            DispatcherService dispatcher = serviceDispatcherMap.get(service);
+            if (dispatcher != null) {
+                dispatcher.invokeOnError(error);
+            }
+        }
     }
 
     public static Object detachService(BObject listener, BObject service) {

--- a/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
+++ b/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
@@ -250,7 +250,10 @@ public class ListenerUtil {
                     injectEvent(dispatcherService, event);
                 } catch (Exception e) {
                     BError error = sfdcError(e.getMessage(), e.getCause());
-                    dispatcherService.invokeOnError(error);
+                    BError onErrorResult = dispatcherService.invokeOnError(error);
+                    if (onErrorResult != null) {
+                        throw onErrorResult;
+                    }
                 }
             };
 

--- a/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
+++ b/native/src/main/java/io/ballerinax/salesforce/ListenerUtil.java
@@ -176,9 +176,7 @@ public class ListenerUtil {
         try {
             params = tokenProvider.login();
         } catch (Exception e) {
-            BError loginError = sfdcError(e.getMessage(), e.getCause());
-            notifyAllDispatchersOnError(listener, loginError);
-            return loginError;
+            return sfdcError(e.getMessage(), e.getCause());
         }
 
         return startConnector(params, tokenProvider, listener);


### PR DESCRIPTION
# Description

$subject 

Fixes # (issue)
https://github.com/ballerina-platform/ballerina-library/issues/8809

Related Pull Requests (remove if not relevant)
- Pull request 1
- Pull request 2

One line release note: 
- One line describing the feature/improvement/fix made by this PR 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Ballerina Version:
* Operating System:
* Java SDK: 

# Checklist:

### Security checks
 - [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds an explicit onError callback path for PlatformEventsService and CdcService so services can receive and handle runtime errors via an onError invocation instead of relying solely on exception propagation.

### Key changes

- Error dispatching
  - DispatcherService now invokes a service onError handler when resource execution returns an error; if onError itself returns an error, that error is propagated.
  - Added public method invokeOnError(BError) to invoke onError with appropriate isolation metadata.

- Listener and notification flow
  - OAuth2/token refresh and subscription failure paths were adjusted to return structured sfdcError values rather than always throwing, changing how login and subscription errors propagate.
  - Subscription event processing now catches per-event exceptions and routes them to dispatchers via invokeOnError.
  - Added listener-level helpers (notifyServicesOnError and notifyAllDispatchersOnError) to notify attached services/dispatchers of listener failures. A Ballerina-side notifyServicesOnError interop was added to call the Java helper.

- Service type documentation
  - Commented placeholders for an onError remote function were added to public service type docs for CdcService and PlatformEventsService (no active signatures changed).

- Constants and interop
  - Added ON_ERROR constant and Java interop helper notifyServicesOnError(Listener, string).

- Tests and dependency updates
  - New tests validate onError behavior for onMessage failures, listener start errors, and subscription failures (test fix: invalid replay id).
  - Patch updates to Ballerina dependencies in ballerina/Dependencies.toml: ballerinax:redis (3.2.1 → 3.2.2), ballerina:crypto (2.12.0 → 2.12.1), ballerina:io (1.8.0 → 1.8.1), ballerina:mime (2.12.1 → 2.12.2), ballerina:task (2.11.1 → 2.11.2).

### Outcomes

Introduces a structured onError callback path to improve runtime error handling and service resilience, adds listener-level error notification utilities, and refreshes several dependencies. Public API signatures were not changed; service type docs include placeholders for the intended callback. The PR description template contains unfilled fields and checklist items were not marked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->